### PR TITLE
Add global audit disable config

### DIFF
--- a/config/audit-logger.php
+++ b/config/audit-logger.php
@@ -5,6 +5,18 @@ declare(strict_types=1);
 return [
     /*
     |--------------------------------------------------------------------------
+    | Audit Logging
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether audit logging is enabled globally. Set
+    | AUDIT_ENABLED=false to disable all audit writes, which is useful for
+    | test environments where audit tables are not required.
+    |
+    */
+    'enabled' => env('AUDIT_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
     | Default Audit Driver
     |--------------------------------------------------------------------------
     |

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -18,6 +18,10 @@ final class AuditLogger
 
     public function log(AuditLogInterface $log): void
     {
+        if (! (bool) config('audit-logger.enabled', true)) {
+            return;
+        }
+
         if ((bool) config('audit-logger.queue.enabled', false)) {
             ProcessAuditLogJob::dispatch($log, $this->driver);
         } else {
@@ -32,6 +36,10 @@ final class AuditLogger
      */
     public function batch(array $logs): void
     {
+        if (! (bool) config('audit-logger.enabled', true)) {
+            return;
+        }
+
         if ((bool) config('audit-logger.queue.enabled', false)) {
             foreach ($logs as $log) {
                 ProcessAuditLogJob::dispatch($log, $this->driver);

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -121,6 +121,10 @@ trait Auditable
      */
     public function isAuditingEnabled(): bool
     {
+        if (! (bool) config('audit-logger.enabled', true)) {
+            return false;
+        }
+
         if (! property_exists($this, 'auditingEnabled')) {
             return true;
         }

--- a/tests/Feature/CustomAuditActionTest.php
+++ b/tests/Feature/CustomAuditActionTest.php
@@ -105,4 +105,35 @@ final class CustomAuditActionTest extends TestCase
             'causer_id' => $this->user->id,
         ]);
     }
+
+    public function test_globally_disabled_auditing_does_not_log_custom_actions(): void
+    {
+        config(['audit-logger.enabled' => false]);
+
+        $auditLogger = app(AuditLogger::class);
+
+        $auditLog = new AuditLog(
+            entityType: Post::class,
+            entityId: $this->post->id,
+            action: 'approved',
+            oldValues: ['status' => 'draft'],
+            newValues: ['status' => 'published'],
+            causerType: User::class,
+            causerId: $this->user->id,
+            metadata: [
+                'approved_by' => $this->user->id,
+                'approved_at' => now()->toDateTimeString(),
+                'comments' => 'Content looks good',
+            ],
+            createdAt: Carbon::now(),
+            source: 'test'
+        );
+
+        $auditLogger->log($auditLog);
+
+        $this->assertDatabaseMissing('audit_posts_logs', [
+            'entity_id' => $this->post->id,
+            'action' => 'approved',
+        ]);
+    }
 }

--- a/tests/Unit/AuditableTraitTest.php
+++ b/tests/Unit/AuditableTraitTest.php
@@ -25,6 +25,17 @@ final class AuditableTraitTest extends TestCase
         $this->assertTrue($user->isAuditingEnabled());
     }
 
+    public function test_global_config_can_disable_auditing(): void
+    {
+        config(['audit-logger.enabled' => false]);
+
+        $user = new User;
+        $this->assertFalse($user->isAuditingEnabled());
+
+        $user->enableAuditing();
+        $this->assertFalse($user->isAuditingEnabled());
+    }
+
     public function test_can_get_audit_entity_type(): void
     {
         $user = new User;
@@ -161,6 +172,38 @@ final class AuditableTraitTest extends TestCase
 
         $user->name = 'Updated Name';
         $user->save();
+
+        $this->assertDatabaseMissing('audit_users_logs', [
+            'entity_id' => $user->id,
+            'action' => 'updated',
+        ]);
+
+        $user->delete();
+
+        $this->assertDatabaseMissing('audit_users_logs', [
+            'entity_id' => $user->id,
+            'action' => 'deleted',
+        ]);
+    }
+
+    public function test_globally_disabled_auditing_does_not_create_logs(): void
+    {
+        config(['audit-logger.enabled' => false]);
+        DB::table('audit_users_logs')->delete();
+
+        $user = User::create([
+            'name' => 'Test User',
+            'email' => 'test@example.com',
+            'password' => 'password',
+            'is_active' => true,
+        ]);
+
+        $this->assertDatabaseMissing('audit_users_logs', [
+            'entity_id' => $user->id,
+            'action' => 'created',
+        ]);
+
+        $user->update(['name' => 'Updated Name']);
 
         $this->assertDatabaseMissing('audit_users_logs', [
             'entity_id' => $user->id,


### PR DESCRIPTION
## Summary
- Add `audit-logger.enabled` backed by `AUDIT_ENABLED`, defaulting to enabled for backward compatibility.
- Make Eloquent model event auditing respect the global flag.
- Make direct/manual audit logging and batch logging no-op when the global flag is disabled.
- Add regression coverage for disabled model event auditing and custom audit logging.

Closes #5.

## Tests
- Not run locally in this environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk and backwards-compatible (defaults to enabled), but introduces a new global switch that can suppress all audit writes if misconfigured.
> 
> **Overview**
> Adds a global `audit-logger.enabled` config (backed by `AUDIT_ENABLED`) to turn off audit logging across the package.
> 
> When disabled, `AuditLogger::log()`/`batch()` become no-ops and the `Auditable` trait reports auditing as disabled, preventing model event audit records from being written. Test coverage is extended to ensure both model-event and custom/manual audit logs are not created when the global flag is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 657490819c4123205c8e0d487f02a26230a60284. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->