### PR TITLE
Add advanced audit APIs and tamper-evident hash chain

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -2,9 +2,9 @@ name: Coding Standards
 
 on:
   push:
-    branches: [ main, master ]
+    branches: [main, master]
   pull_request:
-    branches: [ main, master ]
+    branches: [main, master]
 
 env:
   COMPOSER_PROCESS_TIMEOUT: 0
@@ -13,18 +13,28 @@ env:
 
 jobs:
   phplint:
-      permissions:
-          contents: write
-      runs-on: ubuntu-latest
-      steps:
-          - uses: actions/checkout@v3
-          - name: "laravel-pint"
-            uses: aglipanci/laravel-pint-action@latest
-            with:
-                configPath: './pint.json'
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
 
-          - name: Commit changes
-            uses: stefanzweifel/git-auto-commit-action@v4
-            with:
-                commit_message: PHP Linting (Pint)
-                skip_fetch: true
+      - name: Check Laravel Pint style
+        if: github.event_name == 'pull_request'
+        uses: aglipanci/laravel-pint-action@latest
+        with:
+          configPath: './pint.json'
+          testMode: true
+
+      - name: Fix Laravel Pint style
+        if: github.event_name != 'pull_request'
+        uses: aglipanci/laravel-pint-action@latest
+        with:
+          configPath: './pint.json'
+
+      - name: Commit changes
+        if: github.event_name != 'pull_request'
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: PHP Linting (Pint)
+          skip_fetch: true

--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -18,23 +18,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Check Laravel Pint style
-        if: github.event_name == 'pull_request'
-        uses: aglipanci/laravel-pint-action@latest
         with:
-          configPath: './pint.json'
-          testMode: true
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Fix Laravel Pint style
-        if: github.event_name != 'pull_request'
         uses: aglipanci/laravel-pint-action@latest
         with:
           configPath: './pint.json'
 
       - name: Commit changes
-        if: github.event_name != 'pull_request'
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: PHP Linting (Pint)
           skip_fetch: true
+          branch: ${{ github.head_ref || github.ref_name }}

--- a/README.md
+++ b/README.md
@@ -3,102 +3,162 @@
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/iamfarhad/laravel-audit-log.svg?style=flat-square)](https://packagist.org/packages/iamfarhad/laravel-audit-log)
 [![Total Downloads](https://img.shields.io/packagist/dt/iamfarhad/laravel-audit-log.svg?style=flat-square)](https://packagist.org/packages/iamfarhad/laravel-audit-log)
 [![PHP Version](https://img.shields.io/badge/php-%5E8.1-blue.svg?style=flat-square)](https://packagist.org/packages/iamfarhad/laravel-audit-log)
-[![Laravel Version](https://img.shields.io/badge/Laravel-10.x|11.x|12.x-red.svg?style=flat-square)](https://laravel.com/)
-[![GitHub stars](https://img.shields.io/github/stars/iamfarhad/laravel-audit-log.svg?style=flat-square)](https://github.com/iamfarhad/laravel-audit-log/stargazers)
-
+[![Laravel Version](https://img.shields.io/badge/Laravel-10.x%7C11.x%7C12.x%7C13.x-red.svg?style=flat-square)](https://laravel.com/)
 [![License](https://img.shields.io/packagist/l/iamfarhad/laravel-audit-log.svg?style=flat-square)](https://packagist.org/packages/iamfarhad/laravel-audit-log)
-[![Maintained](https://img.shields.io/badge/maintained-yes-brightgreen.svg?style=flat-square)](https://github.com/iamfarhad/laravel-audit-log)
-[![Tests](https://img.shields.io/github/actions/workflow/status/iamfarhad/laravel-audit-log/tests.yml?branch=main&label=tests&style=flat-square)](https://github.com/iamfarhad/laravel-audit-log/actions/workflows/tests.yml)
-[![Code Style](https://img.shields.io/github/actions/workflow/status/iamfarhad/laravel-audit-log/coding-standards.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/iamfarhad/laravel-audit-log/actions/workflows/coding-standards.yml)
-[![PHPStan](https://img.shields.io/badge/PHPStan-level%205-brightgreen.svg?style=flat-square)](https://github.com/iamfarhad/laravel-audit-log)
 
+**Laravel Audit Logger** is a high-performance, compliance-ready audit logging package for Laravel applications. It tracks Eloquent model changes with entity-specific audit tables, source tracking, queue support, retention policies, timeline/diff APIs, restore/replay helpers, field redaction, and optional tamper-evident hash chains.
 
-## Overview
-
-**Laravel Audit Logger** is a powerful and flexible package designed to provide comprehensive audit logging for Laravel applications. It enables tracking of all changes to your Eloquent models with advanced features including source tracking, queue processing, and customizable field management, ensuring compliance with regulatory requirements, aiding in debugging, and maintaining data integrity. Built with modern PHP and Laravel practices, this package adheres to strict typing, PSR-12 coding standards, and leverages dependency injection for maximum testability and maintainability.
-
-The package uses a high-performance direct logging architecture with optional queue integration, making it suitable for both small applications and enterprise-scale systems.
+The package is designed for serious audit trails in SaaS, ecommerce, admin panels, financial systems, and enterprise Laravel apps where audit data must be searchable, understandable, and trustworthy.
 
 ## Table of Contents
 
 - [Features](#features)
+- [Why Laravel Audit Logger?](#why-laravel-audit-logger)
 - [Requirements](#requirements)
 - [Installation](#installation)
+- [Quick Start](#quick-start)
 - [Configuration](#configuration)
-- [Usage](#usage)
-  - [Basic Usage](#basic-usage)
-  - [Advanced Usage](#advanced-usage)
+- [Advanced Features](#advanced-features)
+  - [Audit Search](#audit-search)
+  - [Analytics](#analytics)
+  - [Timeline and Diff API](#timeline-and-diff-api)
+  - [Restore, Replay, and Rollback](#restore-replay-and-rollback)
+  - [Tamper-Evident Hash Chain](#tamper-evident-hash-chain)
+  - [Field Redaction and Transformers](#field-redaction-and-transformers)
   - [Source Tracking](#source-tracking)
   - [Queue Processing](#queue-processing)
-- [Customizing Audit Logging](#customizing-audit-logging)
-- [Retrieving Audit Logs](#retrieving-audit-logs)
-- [Performance Optimization](#performance-optimization)
+  - [Retention Policies](#retention-policies)
+- [Comparison](#comparison)
 - [Testing](#testing)
 - [Security Best Practices](#security-best-practices)
-- [Audit Log Retention](#audit-log-retention)
-- [Migration & Upgrade Guide](#migration--upgrade-guide)
 - [Troubleshooting](#troubleshooting)
 - [Contributing](#contributing)
 - [License](#license)
 
 ## Features
 
-- **Entity-Specific Audit Tables**: Automatically creates dedicated tables for each audited model to optimize performance and querying.
-- **Comprehensive Change Tracking**: Logs all CRUD operations (create, update, delete, restore) with old and new values.
-- **Advanced Source Tracking**: Automatically tracks the source of changes (console commands, HTTP routes, background jobs) for enhanced debugging and compliance.
-- **Queue Processing**: Supports both synchronous and asynchronous audit log processing for improved performance.
-- **Customizable Field Management**: Control which fields to include or exclude from auditing with global and model-specific configurations.
-- **User Tracking**: Automatically identifies and logs the user (causer) responsible for changes with configurable guard and resolver support.
-- **Direct Logging Architecture**: Uses direct service calls for high-performance logging with optional event integration.
-- **Batch Processing**: Supports batch operations for high-performance logging in large-scale applications.
-- **Type Safety**: Built with PHP 8.1+ strict typing, readonly properties, and modern features.
-- **Enhanced Query Scopes**: Comprehensive filtering capabilities with dedicated scopes for different query patterns.
-- **Extensible Drivers**: Supports multiple storage drivers (currently MySQL) with the ability to implement custom drivers.
-- **Automatic Migration**: Seamlessly creates audit tables for new models when enabled.
-- **Smart Retention System**: Comprehensive retention policies with delete, anonymize, and archive strategies for compliance and performance.
-- **Static Analysis**: Level 5 PHPStan compliance for maximum code quality and reliability.
+- **Entity-specific audit tables**: Stores each model's audit trail in a dedicated table such as `audit_orders_logs` for faster querying and simpler retention.
+- **CRUD and restore tracking**: Captures `created`, `updated`, `deleted`, and `restored` model events.
+- **Old/new value storage**: Stores before-and-after values in JSON/JSONB columns.
+- **Source tracking**: Records whether the change came from an HTTP controller, Artisan command, queue worker, or background job context.
+- **User/causer tracking**: Resolves the authenticated user with configurable guard/model/resolver support.
+- **Audit search API**: Search audit rows across entity id, action, source, causer, metadata, and changed values.
+- **Analytics helpers**: Summary counts, top actions, top causers, top changed entities, and changes per day.
+- **Timeline and diff API**: Generate presentation-friendly audit timelines and field-level diffs for admin panels.
+- **Restore/replay API**: Restore a model from a previous audit entry or roll it back to old values.
+- **Tamper-evident hash chain**: Optional HMAC chain using `audit_hash` and `previous_hash` to detect audit row tampering.
+- **Field redaction and transformers**: Mask, hash, redact, or normalize sensitive values before they are stored.
+- **Queue support**: Run audit writes synchronously or asynchronously.
+- **Retention policies**: Delete, anonymize, or archive old audit logs globally or per model.
+- **MySQL and PostgreSQL drivers**: MySQL uses JSON columns; PostgreSQL uses JSONB columns.
+- **Modern Laravel support**: Laravel 10, 11, 12, and 13 with PHP 8.1+.
+
+## Why Laravel Audit Logger?
+
+Most Laravel logging packages are optimized for general activity feeds. This package is optimized for audit infrastructure:
+
+- dedicated audit tables per entity for performance and isolation;
+- strong compliance features such as retention, anonymization, and hash-chain verification;
+- ergonomic APIs for searching, timeline rendering, diffs, and rollback workflows;
+- clean extension points for custom causer resolvers, storage drivers, metadata, and field transformers.
 
 ## Requirements
 
-- **PHP**: 8.1 or higher
-- **Laravel**: 10.x, 11.x,12.x or 13.x
-- **Database**: MySQL 8.0+ (for the default driver)
+- PHP 8.1 or higher
+- Laravel 10.x, 11.x, 12.x, or 13.x
+- MySQL 8.0+ or PostgreSQL
 
 ## Installation
 
-Install the package via Composer:
+Install the package with Composer:
 
 ```bash
 composer require iamfarhad/laravel-audit-log
 ```
 
-After installation, publish the configuration file to customize settings:
+Publish the configuration file:
 
 ```bash
 php artisan vendor:publish --tag=audit-logger-config
 ```
 
-This will create a configuration file at `config/audit-logger.php` where you can adjust settings like the storage driver, table naming conventions, queue processing, and more.
+This creates:
+
+```text
+config/audit-logger.php
+```
+
+## Quick Start
+
+Add the `Auditable` trait to any Eloquent model:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use iamfarhad\LaravelAuditLog\Traits\Auditable;
+use Illuminate\Database\Eloquent\Model;
+
+final class Order extends Model
+{
+    use Auditable;
+
+    protected $fillable = [
+        'customer_id',
+        'total',
+        'status',
+    ];
+}
+```
+
+The package will automatically log model changes into a table such as:
+
+```text
+audit_orders_logs
+```
+
+Example audit row:
+
+```php
+[
+    'entity_id' => '1',
+    'action' => 'updated',
+    'old_values' => ['status' => 'pending'],
+    'new_values' => ['status' => 'approved'],
+    'causer_type' => App\Models\User::class,
+    'causer_id' => 10,
+    'source' => 'App\Http\Controllers\OrderController@approve',
+    'created_at' => '2026-05-18 10:30:00',
+]
+```
 
 ## Configuration
 
-The configuration file `config/audit-logger.php` allows you to customize the behavior of the audit logger. Below are the key configuration options:
+A typical configuration looks like this:
 
 ```php
 return [
-    // Default audit driver
+    'enabled' => env('AUDIT_ENABLED', true),
+
     'default' => env('AUDIT_DRIVER', 'mysql'),
 
-    // Driver-specific configurations
     'drivers' => [
         'mysql' => [
             'connection' => env('AUDIT_MYSQL_CONNECTION', config('database.default')),
             'table_prefix' => env('AUDIT_TABLE_PREFIX', 'audit_'),
             'table_suffix' => env('AUDIT_TABLE_SUFFIX', '_logs'),
         ],
+
+        'postgresql' => [
+            'connection' => env('AUDIT_PGSQL_CONNECTION', config('database.default')),
+            'table_prefix' => env('AUDIT_TABLE_PREFIX', 'audit_'),
+            'table_suffix' => env('AUDIT_TABLE_SUFFIX', '_logs'),
+        ],
     ],
 
-    // Queue processing configuration
     'queue' => [
         'enabled' => env('AUDIT_QUEUE_ENABLED', false),
         'connection' => env('AUDIT_QUEUE_CONNECTION', config('queue.default')),
@@ -106,17 +166,13 @@ return [
         'delay' => env('AUDIT_QUEUE_DELAY', 0),
     ],
 
-    // Enable automatic migration for audit tables
     'auto_migration' => env('AUDIT_AUTO_MIGRATION', true),
 
-    // Enhanced global field exclusions and configuration
     'fields' => [
         'exclude' => [
             'password',
             'remember_token',
             'api_token',
-            'email_verified_at',
-            'password_hash',
             'secret',
             'token',
             'private_key',
@@ -124,742 +180,165 @@ return [
             'refresh_token',
             'api_key',
             'secret_key',
-            'stripe_id',
-            'pm_type',
-            'pm_last_four',
-            'trial_ends_at',
         ],
         'include_timestamps' => true,
+        'redact' => [],
+        'redaction_replacement' => env('AUDIT_REDACTION_REPLACEMENT', '[REDACTED]'),
+        'transformers' => [],
     ],
 
-    // Enhanced causer identification settings
+    'security' => [
+        'hashing' => [
+            'enabled' => env('AUDIT_HASH_CHAIN_ENABLED', false),
+            'algorithm' => env('AUDIT_HASH_ALGORITHM', 'sha256'),
+            'key' => env('AUDIT_HASH_KEY', env('APP_KEY')),
+        ],
+    ],
+
     'causer' => [
-        'guard' => null, // null means use default guard
-        'model' => null, // null means auto-detect
-        'resolver' => null, // custom resolver class
-    ],
-
-    // Retention configuration for automatic cleanup
-    'retention' => [
-        'enabled' => env('AUDIT_RETENTION_ENABLED', false),
-        'days' => env('AUDIT_RETENTION_DAYS', 365),
-        'strategy' => env('AUDIT_RETENTION_STRATEGY', 'delete'), // 'delete', 'archive', 'anonymize'
-        'batch_size' => env('AUDIT_RETENTION_BATCH_SIZE', 1000),
-        'anonymize_after_days' => env('AUDIT_ANONYMIZE_DAYS', 180),
-        'archive_connection' => env('AUDIT_ARCHIVE_CONNECTION', null),
-        'run_cleanup_automatically' => env('AUDIT_AUTO_CLEANUP', false),
-    ],
-
-    // Registered entities for centralized configuration
-    'entities' => [
-        // Example entity configuration:
-        // \App\Models\User::class => [
-        //     'table' => 'users',
-        //     'exclude' => ['password'],
-        //     'include' => ['*'],
-        //     'retention' => [
-        //         'days' => 730,
-        //         'strategy' => 'anonymize',
-        //         'anonymize_after_days' => 365,
-        //     ],
-        // ],
+        'guard' => null,
+        'model' => null,
+        'resolver' => null,
     ],
 ];
 ```
 
-### Environment Variables
+## Advanced Features
 
-You can use environment variables to configure the audit logger:
+For the full advanced guide, see [`docs/advanced-audit-features.md`](docs/advanced-audit-features.md).
 
-```bash
-# Driver Configuration
-AUDIT_DRIVER=mysql
-AUDIT_MYSQL_CONNECTION=mysql
-AUDIT_TABLE_PREFIX=audit_
-AUDIT_TABLE_SUFFIX=_logs
+### Audit Search
 
-# Queue Configuration
-AUDIT_QUEUE_ENABLED=false
-AUDIT_QUEUE_CONNECTION=redis
-AUDIT_QUEUE_NAME=audit
-AUDIT_QUEUE_DELAY=0
-
-# Migration Configuration
-AUDIT_AUTO_MIGRATION=true
-
-# Retention Configuration
-AUDIT_RETENTION_ENABLED=false
-AUDIT_RETENTION_DAYS=365
-AUDIT_RETENTION_STRATEGY=delete
-AUDIT_RETENTION_BATCH_SIZE=1000
-AUDIT_ANONYMIZE_DAYS=180
-AUDIT_ARCHIVE_CONNECTION=null
-AUDIT_AUTO_CLEANUP=false
-```
-
-### Database Schema
-
-The audit logger creates tables with the following structure for each audited model:
-
-```sql
-CREATE TABLE audit_{model_name}_logs (
-    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
-    entity_id VARCHAR(255) NOT NULL,
-    action VARCHAR(255) NOT NULL,
-    old_values JSON NULL,
-    new_values JSON NULL,
-    causer_type VARCHAR(255) NULL,
-    causer_id VARCHAR(255) NULL,
-    metadata JSON NULL,
-    source VARCHAR(255) NULL,
-    created_at TIMESTAMP NOT NULL,
-    anonymized_at TIMESTAMP NULL,
-    
-    INDEX idx_entity_id (entity_id),
-    INDEX idx_causer (causer_type, causer_id),
-    INDEX idx_created_at (created_at),
-    INDEX idx_source (source),
-    INDEX idx_action (action),
-    INDEX idx_anonymized_at (anonymized_at)
-);
-```
-
-The `source` field is automatically populated to track the origin of changes:
-- Console commands: Command name (e.g., `app:send-emails`)
-- HTTP requests: Controller action (e.g., `App\Http\Controllers\UserController@update`)
-- Background jobs: Job class name
-- Queue workers: Queue job processing context
-
-## Usage
-
-### Basic Usage
-
-To make a model auditable, simply add the `Auditable` trait to your Eloquent model. Ensure strict typing is enabled as per the engineering rules.
+Search audit logs with a fluent query API:
 
 ```php
-<?php
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
 
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class Order extends Model
-{
-    use Auditable;
-
-    protected $fillable = ['customer_id', 'total', 'status'];
-}
-```
-
-Once the trait is added, any changes to the model (create, update, delete, restore) will be automatically logged to a dedicated audit table (e.g., `audit_orders_logs`).
-
-### Authenticated User Tracking
-
-The audit logger automatically tracks WHO made the change and WHERE it came from:
-
-```php
-// When a user makes a change via HTTP request
-Auth::loginUsingId(1);
-$order = Order::create([
-    'customer_id' => 123,
-    'total' => 99.99,
-    'status' => 'pending'
-]);
-
-// Audit log will contain:
-// - causer_type: "App\Models\User"
-// - causer_id: 1
-// - source: "App\Http\Controllers\OrderController@store"
-```
-
-### Retrieving Audit Logs with User Information
-
-You can easily retrieve audit logs with user information:
-
-```php
-// Get audit logs with causer information
-$auditLogs = Order::find(1)->auditLogs()
-    ->where('causer_type', 'App\Models\User')
-    ->where('causer_id', 1)
-    ->get();
-
-// Using the EloquentAuditLog model directly
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-$logs = EloquentAuditLog::forEntity(Order::class)
-    ->forCauser('App\Models\User')
-    ->forCauserId(1)
-    ->get();
-
-// Get logs from HTTP requests only
-$httpLogs = EloquentAuditLog::forEntity(Order::class)
-    ->fromHttp()
-    ->get();
-
-// Get logs from console commands only
-$consoleLogs = EloquentAuditLog::forEntity(Order::class)
-    ->fromConsole()
-    ->get();
-```
-
-### Advanced User Tracking Examples
-
-#### Example 1: Track User Changes in Controller
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Http\Controllers;
-
-use App\Models\Order;
-use Illuminate\Http\Request;
-
-final class OrderController extends Controller
-{
-    public function update(Request $request, Order $order): JsonResponse
-    {
-        // User is already authenticated via middleware
-        // Audit log will automatically capture:
-        // - causer_type: "App\Models\User"
-        // - causer_id: Auth::id()
-        // - source: "App\Http\Controllers\OrderController@update"
-        
-        $order->update($request->validated());
-        
-        return response()->json(['success' => true]);
-    }
-}
-```
-
-#### Example 2: Track System Changes in Console Commands
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Console\Commands;
-
-use App\Models\Order;
-use Illuminate\Console\Command;
-
-final class ProcessOrdersCommand extends Command
-{
-    protected $signature = 'orders:process';
-    
-    public function handle(): void
-    {
-        // For console commands, causer_type and causer_id will be null
-        // But source will be: "orders:process"
-        
-        Order::where('status', 'pending')
-            ->each(function ($order) {
-                $order->update(['status' => 'processed']);
-            });
-    }
-}
-```
-
-#### Example 3: Custom Metadata with User Context
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class Order extends Model
-{
-    use Auditable;
-
-    protected $fillable = ['customer_id', 'total', 'status'];
-
-    /**
-     * Add user context to audit metadata
-     */
-    public function getAuditMetadata(): array
-    {
-        return [
-            'ip_address' => request()->ip() ?? 'unknown',
-            'user_agent' => request()->userAgent() ?? 'unknown',
-            'user_email' => auth()->user()?->email ?? 'system',
-            'session_id' => session()->getId() ?? null,
-            'request_id' => request()->header('X-Request-Id', 'n/a'),
-        ];
-    }
-}
-```
-
-#### Example 4: Querying Audit Logs by User and Source
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Services;
-
-use App\Models\User;
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-final class AuditReportService
-{
-    public function getUserActivity(User $user, string $action = null): array
-    {
-        $query = EloquentAuditLog::forCauser(User::class)
-            ->forCauserId($user->id)
-            ->orderBy('created_at', 'desc');
-            
-        if ($action) {
-            $query->forAction($action);
-        }
-        
-        return $query->get()->map(function ($log) {
-            return [
-                'entity_type' => $log->entity_type,
-                'entity_id' => $log->entity_id,
-                'action' => $log->action,
-                'source' => $log->source,
-                'created_at' => $log->created_at,
-                'metadata' => $log->metadata,
-            ];
-        })->toArray();
-    }
-    
-    public function getHttpRequestChanges(string $controller = null): array
-    {
-        $query = EloquentAuditLog::fromHttp();
-        
-        if ($controller) {
-            $query->fromController($controller);
-        }
-        
-        return $query->get()->toArray();
-    }
-    
-    public function getConsoleChanges(string $command = null): array
-    {
-        $query = EloquentAuditLog::fromConsole();
-        
-        if ($command) {
-            $query->fromCommand($command);
-        }
-        
-        return $query->get()->toArray();
-    }
-}
-```
-
-### Configuration for User Tracking
-
-The causer (user) resolution can be configured in the `config/audit-logger.php` file:
-
-```php
-'causer' => [
-    'guard' => null, // null means use default guard, or specify 'api', 'web', etc.
-    'model' => null, // null means auto-detect, or specify 'App\Models\CustomUser'
-    'resolver' => null, // null means use default resolver, or specify custom class
-],
-```
-
-#### Custom Causer Resolver
-
-You can create a custom causer resolver for complex scenarios:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Services;
-
-use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
-use Illuminate\Support\Facades\Auth;
-
-final class CustomCauserResolver implements CauserResolverInterface
-{
-    public function resolve(): array
-    {
-        // Custom logic for resolving the causer
-        if (Auth::guard('api')->check()) {
-            $user = Auth::guard('api')->user();
-            return [
-                'type' => get_class($user),
-                'id' => $user->id,
-            ];
-        }
-        
-        if (Auth::guard('web')->check()) {
-            $user = Auth::guard('web')->user();
-            return [
-                'type' => get_class($user),
-                'id' => $user->id,
-            ];
-        }
-        
-        // For system operations, you might want to return a system user
-        return [
-            'type' => 'System',
-            'id' => 'system',
-        ];
-    }
-}
-```
-
-Register your custom resolver in a service provider:
-
-```php
-// In AppServiceProvider or custom service provider
-$this->app->bind(
-    \iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface::class,
-    \App\Services\CustomCauserResolver::class
-);
-```
-
-#### Excluding Fields
-
-To exclude specific fields from being audited, define the `$auditExclude` property:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class User extends Model
-{
-    use Auditable;
-
-    protected array $auditExclude = [
-        'password',
-        'remember_token',
-        'email_verified_at',
-    ];
-}
-```
-
-#### Including Specific Fields
-
-Alternatively, you can specify only the fields to audit using `$auditInclude`:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class Invoice extends Model
-{
-    use Auditable;
-
-    protected array $auditInclude = [
-        'amount',
-        'status',
-        'due_date',
-    ];
-}
-```
-
-### Advanced Usage
-
-#### Custom Metadata
-
-You can enrich audit logs with custom metadata by implementing the `getAuditMetadata` method in your model:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class Transaction extends Model
-{
-    use Auditable;
-
-    public function getAuditMetadata(): array
-    {
-        return [
-            'ip_address' => request()->ip() ?? 'unknown',
-            'user_agent' => request()->userAgent() ?? 'unknown',
-            'request_id' => request()->header('X-Request-Id', 'n/a'),
-            'session_id' => session()->getId() ?? null,
-        ];
-    }
-}
-```
-
-#### Source Tracking
-
-The audit logger automatically tracks the source of changes to help with debugging and compliance. The source field captures:
-
-- **Console Commands**: Artisan command names (e.g., `app:send-emails`, `migrate`, `queue:work`)
-- **HTTP Routes**: Controller action names or route names for web requests
-- **Background Jobs**: Job class names when changes occur within queued jobs
-- **Queue Workers**: Processing context for queue-based operations
-
-```php
-// Example audit log entries with source tracking:
-
-// From console command: php artisan app:send-emails
-[
-    'entity_id' => '1',
-    'action' => 'updated',
-    'old_values' => '{"email": "old@example.com"}',
-    'new_values' => '{"email": "new@example.com"}',
-    'source' => 'app:send-emails',
-    'created_at' => '2024-01-15 10:30:00'
-]
-
-// From HTTP request
-[
-    'entity_id' => '1', 
-    'action' => 'updated',
-    'old_values' => '{"status": "pending"}',
-    'new_values' => '{"status": "approved"}',
-    'source' => 'App\\Http\\Controllers\\OrderController@approve',
-    'created_at' => '2024-01-15 10:35:00'
-]
-
-// From background job
-[
-    'entity_id' => '1',
-    'action' => 'updated',
-    'old_values' => '{"processed": false}',
-    'new_values' => '{"processed": true}',
-    'source' => 'App\\Jobs\\ProcessPayment',
-    'created_at' => '2024-01-15 10:40:00'
-]
-```
-
-#### Enhanced Query Scopes for Source Filtering
-
-Query audit logs by source using convenient scopes:
-
-```php
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-// Find all changes made by a specific console command
-$commandLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromCommand('app:send-emails')
-    ->get();
-
-// Find all changes made through console commands
-$consoleLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromConsole()
-    ->get();
-
-// Find all changes made through HTTP requests
-$webLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromHttp()
-    ->get();
-
-// Find changes from a specific controller
-$controllerLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromController('UserController')
-    ->get();
-
-// Find changes by exact source match
-$exactSourceLogs = EloquentAuditLog::forEntity(User::class)
-    ->forSource('app:send-emails')
-    ->get();
-
-// Complex filtering with multiple scopes
-$filteredLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromConsole()
+$logs = AuditLogger::search(App\Models\Order::class, 'approved')
     ->forAction('updated')
-    ->dateBetween(now()->subWeek(), now())
-    ->forCauserId(1)
-    ->orderBy('created_at', 'desc')
-    ->paginate(20);
+    ->between(now()->subMonth(), now())
+    ->latest()
+    ->paginate(50);
 ```
 
-#### Temporarily Disabling Auditing
-
-For specific operations where auditing is not required, you can disable it temporarily:
+Build a query without a keyword:
 
 ```php
-$user = User::find(1);
-$user->disableAuditing();
-$user->update(['email' => 'new.email@example.com']); // This change won't be logged
-$user->enableAuditing();
+$logs = AuditLogger::query(App\Models\Order::class)
+    ->forEntityId($order->id)
+    ->forCauser(App\Models\User::class, auth()->id())
+    ->get();
 ```
 
-#### Custom Audit Events with Fluent API
-
-To log custom actions beyond standard CRUD operations, use the fluent API provided by the `audit()` method:
+### Analytics
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-use App\Models\Order;
-
-$order = Order::find(1);
-$order->audit()
-    ->custom('status_transition')
-    ->from(['status' => 'pending', 'previous_state' => 'draft'])
-    ->to(['status' => 'shipped', 'tracking_number' => 'TRK123456'])
-    ->withMetadata([
-        'ip' => request()->ip(),
-        'user_agent' => request()->userAgent(),
-        'reason' => 'Automatic shipment processing',
-        'batch_id' => 'BATCH_001'
-    ])
-    ->log();
+$summary = AuditLogger::analytics()->summary(App\Models\Order::class);
+$topActions = AuditLogger::analytics()->topActions(App\Models\Order::class);
+$topCausers = AuditLogger::analytics()->topCausers(App\Models\Order::class);
+$topChangedEntities = AuditLogger::analytics()->topChangedEntities(App\Models\Order::class);
+$changesPerDay = AuditLogger::analytics()->changesPerDay(App\Models\Order::class, 30);
 ```
 
-This fluent interface provides:
-- Better performance than event-driven architectures
-- Direct database logging without event dispatch overhead
-- Respects model's auditable attributes
-- Merges default metadata from `getAuditMetadata()` with custom metadata
-- Maintains source tracking for custom events
+### Timeline and Diff API
 
-### Queue Processing
-
-The audit logger supports both synchronous and asynchronous processing of audit logs for improved performance in high-traffic applications.
-
-#### Enabling Queue Processing
-
-Update your configuration to enable queue processing:
+Every auditable model can expose a timeline and field-level diff:
 
 ```php
-// config/audit-logger.php
-'queue' => [
-    'enabled' => true,
-    'connection' => 'redis', // or your preferred queue connection
-    'queue_name' => 'audit',
-    'delay' => 0, // delay in seconds before processing
+$timeline = $order->auditTimeline();
+$latestDiff = $order->auditDiff();
+$specificDiff = $order->auditDiff($auditLogId);
+```
+
+A timeline entry includes:
+
+```php
+[
+    'id' => 100,
+    'action' => 'updated',
+    'entity_id' => '1',
+    'causer_type' => App\Models\User::class,
+    'causer_id' => 10,
+    'source' => 'App\Http\Controllers\OrderController@update',
+    'created_at' => '2026-05-18 10:30:00',
+    'changes' => [
+        ['field' => 'status', 'old' => 'pending', 'new' => 'approved'],
+    ],
+    'metadata' => [],
+    'audit_hash' => '...',
+    'previous_hash' => '...',
+]
+```
+
+### Restore, Replay, and Rollback
+
+Replay the new values from an audit log:
+
+```php
+$order->restoreFromAudit($auditLogId);
+```
+
+Rollback to the old values captured by an audit log:
+
+```php
+$order->rollbackToAudit($auditLogId);
+```
+
+Preview a restore/rollback before saving:
+
+```php
+$preview = $order->previewRestore($auditLogId, 'rollback');
+```
+
+### Tamper-Evident Hash Chain
+
+Enable hash-chain verification:
+
+```env
+AUDIT_HASH_CHAIN_ENABLED=true
+AUDIT_HASH_ALGORITHM=sha256
+AUDIT_HASH_KEY=your-private-audit-key
+```
+
+When enabled, every audit row stores:
+
+- `previous_hash`: the previous audit row hash for the same audit table;
+- `audit_hash`: an HMAC of the canonical audit payload plus `previous_hash`.
+
+Verify an audit chain:
+
+```php
+$result = AuditLogger::verifyHashChain(App\Models\Order::class);
+
+if (! $result['valid']) {
+    report($result['failures']);
+}
+```
+
+### Field Redaction and Transformers
+
+Redact sensitive fields with a fixed replacement:
+
+```php
+'fields' => [
+    'redact' => ['national_id', 'card_number'],
+    'redaction_replacement' => '[REDACTED]',
 ],
 ```
 
-Or use environment variables:
-
-```bash
-AUDIT_QUEUE_ENABLED=true
-AUDIT_QUEUE_CONNECTION=redis
-AUDIT_QUEUE_NAME=audit
-AUDIT_QUEUE_DELAY=0
-```
-
-#### Queue Jobs Architecture
-
-The package includes two specialized queue jobs:
-
-1. **`ProcessAuditLogJob`**: Handles standard asynchronous audit log processing
-2. **`ProcessAuditLogSyncJob`**: Provides fallback synchronous processing when needed
-
-#### Queue Configuration Options
-
-- **`enabled`**: Boolean to enable/disable queue processing (default: `false`)
-- **`connection`**: Queue connection to use (default: your app's default queue connection)
-- **`queue_name`**: Name of the queue to dispatch audit jobs to (default: `audit`)
-- **`delay`**: Delay in seconds before processing the job (default: `0` for immediate processing)
-
-#### Benefits of Queue Processing
-
-1. **Improved Performance**: Audit logging doesn't block your application's main thread
-2. **Scalability**: Handle high-volume audit logging without impacting user experience
-3. **Reliability**: Failed audit logs can be retried automatically with Laravel's queue system
-4. **Resource Management**: Control when and how audit logs are processed
-5. **Better Error Handling**: Queue-specific error handling and monitoring
-
-#### Queue Worker Setup
-
-When using queue processing, ensure you have queue workers running:
-
-```bash
-# Start a queue worker specifically for the audit queue
-php artisan queue:work --queue=audit
-
-# Or run workers for all queues
-php artisan queue:work
-
-# For production with process management
-php artisan queue:work --queue=audit --tries=3 --timeout=60
-```
-
-For production environments, consider using Supervisor or similar process managers to keep your queue workers running reliably.
-
-## Customizing Audit Logging
-
-### Custom Driver Implementation
-
-If you need to extend the audit logging functionality, you can implement a custom driver by adhering to the `AuditDriverInterface`:
+Transform fields before storage:
 
 ```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Audit\Drivers;
-
-use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
-use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
-
-final class CustomAuditDriver implements AuditDriverInterface
-{
-    public function log(AuditLog $auditLog): void
-    {
-        // Your custom logging implementation
-    }
-
-    public function createStorageForEntity(string $entityClass): void
-    {
-        // Your custom storage creation logic
-    }
-
-    // ... implement other required methods
-}
+'fields' => [
+    'transformers' => [
+        'email' => \iamfarhad\LaravelAuditLog\Transformers\MaskEmailTransformer::class,
+        'phone' => \iamfarhad\LaravelAuditLog\Transformers\MaskValueTransformer::class,
+        'api_token' => \iamfarhad\LaravelAuditLog\Transformers\HashValueTransformer::class,
+    ],
+],
 ```
 
-Register your custom driver in a service provider:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Providers;
-
-use Illuminate\Support\ServiceProvider;
-use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
-use App\Audit\Drivers\CustomAuditDriver;
-
-final class AuditServiceProvider extends ServiceProvider
-{
-    public function register(): void
-    {
-        $this->app->bind(AuditDriverInterface::class, CustomAuditDriver::class);
-    }
-}
-```
-
-### Custom Causer Resolver
-
-You can implement a custom causer resolver for complex authentication scenarios:
+Create a custom transformer:
 
 ```php
 <?php
@@ -868,737 +347,175 @@ declare(strict_types=1);
 
 namespace App\Audit;
 
-use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
 use Illuminate\Database\Eloquent\Model;
 
-final class CustomCauserResolver implements CauserResolverInterface
+final class MoneyTransformer implements FieldTransformerInterface
 {
-    public function resolve(): ?Model
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed
     {
-        // Your custom causer resolution logic
-        return auth()->user() ?? $this->getSystemUser();
-    }
-
-    private function getSystemUser(): ?Model
-    {
-        // Return a system user for automated processes
-        return User::where('email', 'system@example.com')->first();
+        return number_format((float) $value, 2, '.', '');
     }
 }
 ```
 
-## Retrieving Audit Logs
+### Source Tracking
 
-### Model Relationship
+The package automatically records where a change came from:
 
-Audit logs are accessible via a relationship on the audited model:
+- HTTP controller action, such as `App\Http\Controllers\OrderController@update`
+- Artisan command, such as `orders:process`
+- Queue/background job context when available
+
+Use source scopes:
 
 ```php
-$user = User::find(1);
-
-// Retrieve all audit logs
-$allLogs = $user->auditLogs()->get();
-
-// Filter by specific action
-$updateLogs = $user->auditLogs()->where('action', 'updated')->get();
-
-// Get the most recent logs with pagination
-$recentLogs = $user->auditLogs()
-    ->orderBy('created_at', 'desc')
-    ->paginate(10);
-
-// Include metadata and causer information
-$detailedLogs = $user->auditLogs()
-    ->with(['causer'])
-    ->orderBy('created_at', 'desc')
-    ->get();
+$httpLogs = EloquentAuditLog::forEntity(Order::class)->fromHttp()->get();
+$consoleLogs = EloquentAuditLog::forEntity(Order::class)->fromConsole()->get();
+$commandLogs = EloquentAuditLog::forEntity(Order::class)->fromCommand('orders:process')->get();
 ```
 
-### Advanced Querying with EloquentAuditLog
+### Queue Processing
 
-For more complex queries, use the `EloquentAuditLog` model directly with comprehensive scopes:
+Enable queue processing:
 
-```php
-<?php
-
-declare(strict_types=1);
-
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-// Basic entity filtering
-$logs = EloquentAuditLog::forEntity(User::class)
-    ->forEntityId(1)
-    ->orderBy('created_at', 'desc')
-    ->get();
-
-// Complex multi-criteria filtering
-$filteredLogs = EloquentAuditLog::forEntity(Order::class)
-    ->forAction('updated')
-    ->forCauserId(1)
-    ->fromCommand('app:process-orders')
-    ->dateBetween(now()->subWeek(), now())
-    ->orderBy('created_at', 'desc')
-    ->paginate(20);
-
-// Source-specific queries
-$consoleLogs = EloquentAuditLog::forEntity(User::class)
-    ->fromConsole()
-    ->dateGreaterThan(now()->subHour())
-    ->get();
-
-$controllerLogs = EloquentAuditLog::forEntity(Order::class)
-    ->fromController('OrderController')
-    ->forAction(['created', 'updated'])
-    ->get();
-
-// Aggregation and analytics
-$dailyStats = EloquentAuditLog::forEntity(User::class)
-    ->selectRaw('DATE(created_at) as date, action, COUNT(*) as count')
-    ->dateBetween(now()->subMonth(), now())
-    ->groupBy('date', 'action')
-    ->orderBy('date', 'desc')
-    ->get();
+```env
+AUDIT_QUEUE_ENABLED=true
+AUDIT_QUEUE_CONNECTION=redis
+AUDIT_QUEUE_NAME=audit
 ```
 
-### Available Query Scopes
+Run an audit worker:
 
-The `EloquentAuditLog` model provides comprehensive scopes for efficient filtering:
+```bash
+php artisan queue:work --queue=audit --tries=3 --timeout=60
+```
 
-#### Entity and Basic Filtering
-- `forEntity(string $entityClass)` - Filter by entity type
-- `forEntityId($entityId)` - Filter by entity ID
-- `forAction(string|array $action)` - Filter by action(s)
-- `forCauser(string $causerClass)` - Filter by causer type
-- `forCauserId($causerId)` - Filter by causer ID
+### Retention Policies
 
-#### Date Filtering
-- `forCreatedAt($createdAt)` - Filter by exact creation date
-- `dateGreaterThan($date)` - Filter for logs after a specific date
-- `dateLessThan($date)` - Filter for logs before a specific date
-- `dateBetween($startDate, $endDate)` - Filter for logs within a date range
-
-#### Enhanced Source Filtering
-- `forSource(string $source)` - Filter by exact source match
-- `fromConsole()` - Filter for logs from console commands
-- `fromHttp()` - Filter for logs from HTTP requests
-- `fromCommand(string $command)` - Filter by specific console command
-- `fromController(?string $controller = null)` - Filter by controller
-
-## Performance Optimization
-
-### Database Optimization
-- **Automatic Indexing**: The package automatically creates indexes on frequently queried columns (`entity_id`, `causer_type`, `causer_id`, `created_at`, `source`, `action`)
-- **Entity-Specific Tables**: Each model gets its own audit table for optimal query performance
-- **JSON Column Usage**: Efficiently stores old/new values and metadata using MySQL's native JSON support
-
-### Application-Level Optimization
-- **Queue Processing**: Enable queue processing for high-traffic applications to improve response times
-- **Selective Auditing**: Limit audited fields to only those necessary for compliance or debugging
-- **Batch Operations**: Use the audit service's batch capabilities for bulk operations
-- **Strategic Field Exclusion**: Configure global and model-specific field exclusions to reduce storage overhead
-
-### Recommended Configuration for High-Traffic Applications
+The package supports delete, anonymize, and archive strategies:
 
 ```php
-// config/audit-logger.php
-return [
-'queue' => [
-    'enabled' => true,
-        'connection' => 'redis',
-    'queue_name' => 'audit',
-    ],
-    'fields' => [
-        'exclude' => [
-            // Add non-critical fields to reduce storage
-            'updated_at',
-            'last_activity',
-            'view_count',
+'entities' => [
+    App\Models\User::class => [
+        'retention' => [
+            'enabled' => true,
+            'days' => 730,
+            'strategy' => 'anonymize',
+            'anonymize_after_days' => 365,
         ],
-        'include_timestamps' => false, // Disable if not needed
     ],
-];
+],
 ```
 
-### Monitoring and Maintenance
+Run cleanup manually:
 
-```php
-// Example service for audit log maintenance
-<?php
-
-declare(strict_types=1);
-
-namespace App\Services;
-
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-final class AuditMaintenanceService
-{
-    public function cleanupOldLogs(int $daysToKeep = 365): int
-    {
-        return EloquentAuditLog::where('created_at', '<', now()->subDays($daysToKeep))
-            ->delete();
-    }
-
-    public function getStorageStats(): array
-    {
-        return [
-            'total_logs' => EloquentAuditLog::count(),
-            'logs_last_30_days' => EloquentAuditLog::dateGreaterThan(now()->subDays(30))->count(),
-            'most_active_entities' => EloquentAuditLog::selectRaw('entity_type, COUNT(*) as count')
-                ->groupBy('entity_type')
-                ->orderBy('count', 'desc')
-                ->limit(10)
-                ->get(),
-        ];
-    }
-}
+```bash
+php artisan audit:cleanup --dry-run
+php artisan audit:cleanup --force
 ```
+
+## Comparison
+
+| Capability | Laravel Audit Logger | Spatie Activitylog | Laravel Auditing |
+|---|---:|---:|---:|
+| Entity-specific audit tables | Yes | No | No |
+| MySQL storage | Yes | Yes | Yes |
+| PostgreSQL storage | Yes | Via database support | Via database support |
+| Queue support | Yes | App-managed | App-managed |
+| Source tracking | Yes | Partial/manual | Resolver-based |
+| Audit search API | Yes | Query activity model | Query audit model |
+| Analytics helpers | Yes | No built-in analytics helper | No built-in analytics helper |
+| Timeline/diff API | Yes | Manual formatting | Auditable transition data |
+| Restore/replay API | Yes | No built-in model restore | Limited/manual workflows |
+| Tamper-evident hash chain | Yes | No | No |
+| Field redactors/transformers | Yes | Custom pipes/manual | Attribute modifiers/resolvers |
+| Retention strategies | Delete, anonymize, archive | Manual cleanup | Manual cleanup |
 
 ## Testing
 
-This package includes a comprehensive test suite with high coverage. To run the tests locally:
+Run the test suite:
 
 ```bash
-# Run the full test suite
 composer test
-
-# Run with coverage
-composer test:coverage
-
-# Run specific test suites
-vendor/bin/phpunit tests/Unit/
-vendor/bin/phpunit tests/Feature/
 ```
 
-### Test Categories
+Run static analysis and style checks:
 
-The test suite includes:
+```bash
+composer analyse
+composer pint:test
+```
 
-- **Unit Tests**: Test individual components in isolation
-  - `AuditLoggerServiceTest`: Service layer testing
-  - `MySQLDriverTest`: Driver functionality
-  - `CauserResolverTest`: User identification
-  - `AuditableTraitTest`: Trait functionality
+Fix style automatically:
 
-- **Feature Tests**: Test integration between components
-  - `AuditLogIntegrationTest`: Full integration scenarios
-  - `AuditLogBatchTest`: Batch processing
-  - `CustomAuditActionTest`: Custom audit events
-
-- **Integration Tests**: Test real-world scenarios with database
-
-### Testing Your Implementation
-
-When writing tests for your application, ensure you cover audit logging behavior:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace Tests\Feature;
-
-use Tests\TestCase;
-use App\Models\User;
-use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
-
-final class UserAuditTest extends TestCase
-{
-    public function test_user_creation_is_audited(): void
-    {
-        $user = User::create([
-            'name' => 'John Doe',
-            'email' => 'john@example.com',
-        ]);
-
-        $this->assertDatabaseHas('audit_users_logs', [
-            'entity_id' => $user->id,
-            'action' => 'created',
-        ]);
-
-        $auditLog = EloquentAuditLog::forEntity(User::class)
-            ->forEntityId($user->id)
-            ->forAction('created')
-            ->first();
-
-        $this->assertNotNull($auditLog);
-        $this->assertEquals('created', $auditLog->action);
-        $this->assertNotNull($auditLog->new_values);
-    }
-
-    public function test_sensitive_fields_are_excluded(): void
-    {
-        $user = User::create([
-            'name' => 'John Doe',
-            'email' => 'john@example.com',
-            'password' => bcrypt('secret'),
-        ]);
-
-        $auditLog = EloquentAuditLog::forEntity(User::class)
-            ->forEntityId($user->id)
-            ->first();
-
-        $newValues = json_decode($auditLog->new_values, true);
-        $this->assertArrayNotHasKey('password', $newValues);
-    }
-}
+```bash
+composer pint
 ```
 
 ## Security Best Practices
 
-### Data Protection
-- **Exclude Sensitive Data**: Always exclude fields containing PII or sensitive data using `$auditExclude` or global configuration
-- **Enhanced Security Fields**: The package now excludes common sensitive fields by default (API keys, tokens, payment information)
-- **Metadata Sanitization**: Be cautious about what data you include in custom metadata
-
-### Access Control
-- **Authorization Gates**: Implement Laravel Gates or Policies to restrict access to audit logs
-- **Role-Based Access**: Consider different access levels for different types of audit data
-- **API Protection**: If exposing audit logs via API, ensure proper authentication and rate limiting
-
-### Data Retention and Compliance
-- **Retention Policies**: Implement automated cleanup of old audit logs based on your compliance requirements
-- **GDPR Compliance**: Consider implementing user data deletion when users request account deletion
-- **Export Capabilities**: Provide audit trail export functionality for compliance reporting
-
-```php
-// Example policy for audit log access
-<?php
-
-declare(strict_types=1);
-
-namespace App\Policies;
-
-use App\Models\User;
-use Illuminate\Auth\Access\HandlesAuthorization;
-
-final class AuditLogPolicy
-{
-    use HandlesAuthorization;
-
-    public function viewAny(User $user): bool
-    {
-        return $user->hasPermission('audit.view');
-    }
-
-    public function view(User $user, string $entityType, $entityId): bool
-    {
-        return $user->hasPermission('audit.view') 
-            && $this->canAccessEntity($user, $entityType, $entityId);
-    }
-
-    private function canAccessEntity(User $user, string $entityType, $entityId): bool
-    {
-        // Implement your business logic for entity access
-        return true;
-    }
-}
-```
-
-## Audit Log Retention
-
-The Laravel Audit Logger package includes a powerful retention system that helps you manage the lifecycle of your audit logs. This system supports automatic cleanup, anonymization, and archiving of old audit data to help with compliance requirements and database performance.
-
-### Features
-
-- **Multiple Retention Strategies**: Delete, anonymize, or archive old audit logs
-- **Per-Model Configuration**: Override global settings for specific models
-- **Batch Processing**: Efficient processing of large datasets
-- **Smart Anonymization**: Automatically detect and anonymize sensitive fields
-- **Flexible Scheduling**: Run manually or via scheduled jobs
-- **Dry Run Mode**: Preview changes before execution
-
-### Configuration
-
-#### Global Configuration
-
-Configure retention settings in your `config/audit-logger.php`:
-
-```php
-'retention' => [
-    'enabled' => env('AUDIT_RETENTION_ENABLED', false),
-    'days' => env('AUDIT_RETENTION_DAYS', 365),
-    'strategy' => env('AUDIT_RETENTION_STRATEGY', 'delete'), // 'delete', 'archive', 'anonymize'
-    'batch_size' => env('AUDIT_RETENTION_BATCH_SIZE', 1000),
-    'anonymize_after_days' => env('AUDIT_ANONYMIZE_DAYS', 180),
-    'archive_connection' => env('AUDIT_ARCHIVE_CONNECTION', null),
-    'run_cleanup_automatically' => env('AUDIT_AUTO_CLEANUP', false),
-],
-```
-
-#### Environment Variables
-
-```env
-AUDIT_RETENTION_ENABLED=true
-AUDIT_RETENTION_DAYS=365
-AUDIT_RETENTION_STRATEGY=delete
-AUDIT_RETENTION_BATCH_SIZE=1000
-AUDIT_ANONYMIZE_DAYS=180
-AUDIT_ARCHIVE_CONNECTION=archive_db
-AUDIT_AUTO_CLEANUP=false
-```
-
-#### Per-Entity Configuration
-
-Configure retention settings for specific entities:
-
-```php
-'entities' => [
-    \App\Models\User::class => [
-        'table' => 'users',
-        'retention' => [
-            'enabled' => true,
-            'days' => 730, // Keep for 2 years
-            'strategy' => 'anonymize',
-            'anonymize_after_days' => 365, // Anonymize after 1 year
-        ],
-    ],
-    \App\Models\Order::class => [
-        'table' => 'orders',
-        'retention' => [
-            'days' => 2555, // Keep for 7 years (compliance)
-            'strategy' => 'archive',
-        ],
-    ],
-],
-```
-
-#### Per-Model Configuration
-
-Configure retention directly in your model:
-
-```php
-<?php
-
-declare(strict_types=1);
-
-namespace App\Models;
-
-use Illuminate\Database\Eloquent\Model;
-use iamfarhad\LaravelAuditLog\Traits\Auditable;
-
-final class User extends Model
-{
-    use Auditable;
-
-    // Per-model retention configuration
-    protected array $auditRetention = [
-        'enabled' => true,
-        'days' => 730,
-        'strategy' => 'anonymize',
-        'anonymize_after_days' => 365,
-    ];
-}
-```
-
-### Retention Strategies
-
-#### 1. Delete Strategy
-
-Permanently removes old audit logs from the database.
-
-```php
-'strategy' => 'delete',
-'days' => 365, // Delete records older than 1 year
-```
-
-**Use Case**: When you want to minimize storage usage and don't need historical data beyond a certain period.
-
-#### 2. Anonymize Strategy
-
-Replaces sensitive information with anonymized values while keeping the audit structure intact.
-
-```php
-'strategy' => 'anonymize',
-'days' => 180, // Anonymize records older than 6 months
-```
-
-**Anonymized Fields**: email, phone, address, ip_address, user_agent, name, first_name, last_name, full_name
-
-**Use Case**: Compliance requirements where you need to maintain audit trail structure but remove personally identifiable information.
-
-#### 3. Archive Strategy
-
-Moves old audit logs to a separate database connection for long-term storage.
-
-```php
-'strategy' => 'archive',
-'days' => 365, // Archive records older than 1 year
-'archive_connection' => 'archive_db',
-```
-
-**Use Case**: Long-term compliance requirements where you need to maintain historical data but keep the primary database lean.
-
-#### 4. Combined Strategy
-
-You can combine anonymization with deletion or archiving:
-
-```php
-'strategy' => 'delete', // or 'archive'
-'days' => 730, // Final action after 2 years
-'anonymize_after_days' => 365, // Anonymize after 1 year
-```
-
-### Usage
-
-#### Manual Execution
-
-```bash
-# Run cleanup for all entities
-php artisan audit:cleanup --force
-
-# Run cleanup for specific entity
-php artisan audit:cleanup --entity="App\Models\User" --force
-
-# Dry run to see what would be processed
-php artisan audit:cleanup --dry-run
-
-# Process specific number of records
-php artisan audit:cleanup --limit=1000 --force
-```
-
-#### Queue Processing
-
-```php
-use iamfarhad\LaravelAuditLog\Jobs\RetentionCleanupJob;
-
-// Dispatch cleanup job for all entities
-RetentionCleanupJob::dispatch();
-
-// Dispatch cleanup job for specific entity  
-RetentionCleanupJob::dispatch('App\Models\User');
-```
-
-#### Scheduled Execution
-
-Add to your `app/Console/Kernel.php`:
-
-```php
-protected function schedule(Schedule $schedule): void
-{
-    // Run retention cleanup weekly
-    $schedule->command('audit:cleanup --force')
-        ->weekly()
-        ->environments(['production']);
-    
-    // Or run for specific entities
-    $schedule->command('audit:cleanup --entity="App\Models\User" --force')
-        ->daily()
-        ->at('02:00');
-}
-```
-
-#### Service Usage
-
-```php
-<?php
-
-declare(strict_types=1);
-
-use iamfarhad\LaravelAuditLog\Contracts\RetentionServiceInterface;
-use iamfarhad\LaravelAuditLog\DTOs\RetentionConfig;
-
-final class AuditMaintenanceService
-{
-    public function __construct(
-        private readonly RetentionServiceInterface $retentionService
-    ) {}
-
-    public function cleanupUserAudits(): void
-    {
-        $config = new RetentionConfig(
-            enabled: true,
-            days: 365,
-            strategy: 'anonymize',
-            batchSize: 1000,
-            anonymizeAfterDays: 180
-        );
-
-        $result = $this->retentionService->processRetention(
-            entityClass: 'App\Models\User',
-            config: $config,
-            dryRun: false
-        );
-
-        // Handle results...
-    }
-}
-```
-
-### Best Practices
-
-1. **Start with Dry Runs**: Always test your retention policies with `--dry-run` before applying
-2. **Monitor Performance**: Use appropriate batch sizes for your database performance
-3. **Backup Strategy**: Ensure you have backups before running retention operations
-4. **Compliance Review**: Review your retention policies with legal/compliance teams
-5. **Gradual Implementation**: Start with longer retention periods and adjust based on requirements
-6. **Queue Processing**: Use queued processing for large datasets to avoid timeouts
-
-### Security Considerations
-
-- **Access Control**: Ensure only authorized users can execute retention commands
-- **Audit the Audit**: Consider logging retention operations themselves
-- **Data Recovery**: Have procedures for data recovery in case of mistakes
-- **Anonymization Verification**: Test that anonymized data meets your privacy requirements
-
-## Migration & Upgrade Guide
-
-### Upgrading from Version 1.2.x to 1.3.x
-
-Version 1.3.0 introduced breaking changes with the move from event-driven to direct logging architecture:
-
-#### Breaking Changes
-- **Event System Removed**: `ModelAudited` event and `AuditModelChanges` listener have been removed
-- **Direct Logging**: The system now uses direct service calls instead of event dispatching
-- **Enhanced Configuration**: New configuration options for causer resolution and entity management
-
-#### Migration Steps
-
-1. **Update Configuration**: Publish the new configuration file:
-   ```bash
-   php artisan vendor:publish --tag=audit-logger-config --force
-   ```
-
-2. **Database Schema**: Add the `source` column to existing audit tables:
-  ```sql
-  ALTER TABLE audit_your_model_logs ADD COLUMN source VARCHAR(255) NULL;
-  CREATE INDEX idx_source ON audit_your_model_logs (source);
-  ```
-
-3. **Remove Event Listeners**: If you were listening to `ModelAudited` events, replace with direct service usage or custom implementations.
-
-4. **Test Your Implementation**: Ensure all audit logging continues to work as expected.
-
-### Upgrading from Version 1.1.x to 1.2.x
-
-Version 1.2.0 introduced structural changes:
-
-- **DTO Introduction**: `AuditLog` moved from Models to DTOs namespace
-- **Enhanced EloquentAuditLog**: New model with comprehensive scopes
-- **Improved Test Suite**: Better test coverage and organization
-
-Most changes are backward compatible, but you should update any direct references to the old `AuditLog` model class.
+- Exclude or redact secrets, tokens, passwords, API keys, and payment fields.
+- Use field transformers for PII that must be retained in masked or hashed form.
+- Store `AUDIT_HASH_KEY` securely and rotate it intentionally.
+- Restrict audit log access with Laravel policies/gates.
+- Use retention policies for privacy and compliance requirements.
+- Run `AuditLogger::verifyHashChain()` periodically if hash-chain mode is enabled.
 
 ## Troubleshooting
 
-### Common Issues and Solutions
+### Audit tables are not created
 
-#### Audit Tables Not Created
-- **Solution**: Ensure `'auto_migration' => true` in your configuration
-- **Manual Creation**: Use `AuditLogger::driver()->createStorageForEntity(Model::class)`
-
-#### Missing Logs
-- **Check Field Exclusion**: Verify fields aren't excluded globally or in the model
-- **Auditing Status**: Ensure auditing isn't disabled for the operation
-- **Queue Processing**: If using queues, ensure workers are running
-
-#### Causer Not Recorded
-- **Authentication**: Confirm user is logged in during the operation
-- **Guard Configuration**: Check the causer guard configuration
-- **Custom Resolver**: Verify custom causer resolver implementation
-
-#### Source Field Issues
-- **Console Commands**: Ensure `$_SERVER['argv']` is available
-- **HTTP Requests**: Verify route is properly registered
-- **Context Detection**: Check application is running in expected context
-
-#### Queue Processing Issues
-- **Worker Status**: Ensure queue workers are running: `php artisan queue:work --queue=audit`
-- **Connection**: Verify queue connection is properly configured
-- **Failed Jobs**: Monitor with `php artisan queue:failed`
-- **Debugging**: Temporarily disable queues to test synchronous processing
-
-#### Performance Issues
-- **Enable Queues**: For high-traffic applications, enable queue processing
-- **Field Exclusion**: Exclude non-essential fields to reduce storage overhead
-- **Database Optimization**: Ensure proper indexing (handled automatically)
-- **Batch Operations**: Use batch processing for bulk operations
-
-#### Static Analysis Errors
-- **PHPStan**: The package is PHPStan Level 5 compliant
-- **Dynamic Methods**: Some warnings about dynamic method calls are expected and ignored
-- **Type Safety**: Ensure strict typing is enabled in your models
-
-### Debug Mode
-
-Enable debug logging to troubleshoot issues:
+Check:
 
 ```php
-// In your service provider or configuration
-use iamfarhad\LaravelAuditLog\Services\AuditLogger;
-
-// Enable debug mode (not recommended for production)
-AuditLogger::enableDebugMode();
-
-// This will log additional information about audit processing
+'audit-logger.auto_migration' => true
 ```
 
-### Getting Help
+Or create storage manually through the configured driver.
 
-1. **Check Documentation**: Review this README and the changelog
-2. **Search Issues**: Look through existing GitHub issues
-3. **Create Issue**: If you find a bug, create a detailed issue with:
-   - Laravel version
-   - PHP version
-   - Package version
-   - Minimal reproduction steps
-   - Expected vs actual behavior
+### Causer is not recorded
+
+Check that the user is authenticated during the operation, and verify your configured guard:
+
+```php
+'causer' => [
+    'guard' => 'web',
+]
+```
+
+### Queued logs are missing
+
+Make sure queue workers are running:
+
+```bash
+php artisan queue:work --queue=audit
+```
+
+### Hash verification fails
+
+Possible causes:
+
+- audit rows were edited manually;
+- `AUDIT_HASH_KEY` changed;
+- old rows existed before hash-chain mode was enabled;
+- records were imported without preserving hash order.
 
 ## Contributing
 
-Contributions are welcome! Please follow these guidelines:
+Contributions are welcome.
 
-### Development Setup
-
-1. **Fork the Repository**: Create your own fork of the project
-2. **Clone Locally**: `git clone your-fork-url`
-3. **Install Dependencies**: `composer install`
-4. **Run Tests**: `composer test` to ensure everything works
-
-### Code Standards
-
-- **PSR-12**: Follow PSR-12 coding standards
-- **Strict Types**: Use `declare(strict_types=1);` in all PHP files
-- **Type Hints**: Provide type hints for all parameters and return values
-- **PHPStan**: Code must pass PHPStan Level 5 analysis
-- **Tests**: Include tests for new features and bug fixes
-
-### Pull Request Process
-
-1. **Create Branch**: Create a feature branch from `main`
-2. **Write Code**: Implement your changes following the code standards
-3. **Add Tests**: Include comprehensive tests for your changes
-4. **Update Documentation**: Update README and changelog as needed
-5. **Run Quality Checks**: 
-   ```bash
-   composer test
-   composer pint
-   composer phpstan
-   ```
-6. **Submit PR**: Create a detailed pull request with description of changes
-
-### Code Quality Tools
-
-The project uses several quality assurance tools:
+Before opening a pull request:
 
 ```bash
-# Run all tests
+composer install
 composer test
-
-# Fix code style
-composer pint
-
-# Run static analysis
-composer phpstan
-
-# Check test coverage
-composer test:coverage
+composer analyse
+composer pint:test
 ```
+
+Please include tests and documentation for new features.
 
 ## License
 
-This package is open-sourced software licensed under the [MIT license](LICENSE.md).
-
----
-
-**Laravel Audit Logger** - Comprehensive audit logging for modern Laravel applications with advanced source tracking, queue processing, and enterprise-grade features.
+The MIT License (MIT). See [LICENSE.md](LICENSE.md).

--- a/config/audit-logger.php
+++ b/config/audit-logger.php
@@ -3,39 +3,10 @@
 declare(strict_types=1);
 
 return [
-    /*
-    |--------------------------------------------------------------------------
-    | Audit Logging
-    |--------------------------------------------------------------------------
-    |
-    | This option controls whether audit logging is enabled globally. Set
-    | AUDIT_ENABLED=false to disable all audit writes, which is useful for
-    | test environments where audit tables are not required.
-    |
-    */
     'enabled' => env('AUDIT_ENABLED', true),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Default Audit Driver
-    |--------------------------------------------------------------------------
-    |
-    | This option controls the default audit driver that will be used to store
-    | audit logs.
-    |
-    | Supported: "mysql", "postgresql"
-    |
-    */
     'default' => env('AUDIT_DRIVER', 'mysql'),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Audit Drivers
-    |--------------------------------------------------------------------------
-    |
-    | Here you may configure the audit drivers for your application.
-    |
-    */
     'drivers' => [
         'mysql' => [
             'connection' => env('AUDIT_MYSQL_CONNECTION', config('database.default')),
@@ -50,16 +21,6 @@ return [
         ],
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Queue Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Configure whether audit logs should be processed asynchronously using
-    | Laravel's queue system. When enabled, audit logs will be dispatched
-    | to the specified queue for background processing.
-    |
-    */
     'queue' => [
         'enabled' => env('AUDIT_QUEUE_ENABLED', false),
         'connection' => env('AUDIT_QUEUE_CONNECTION', config('queue.default')),
@@ -67,26 +28,8 @@ return [
         'delay' => env('AUDIT_QUEUE_DELAY', 0),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Auto Migration
-    |--------------------------------------------------------------------------
-    |
-    | This option allows you to control whether audit tables are automatically
-    | created for new entity types when they are first logged.
-    |
-    */
     'auto_migration' => env('AUDIT_AUTO_MIGRATION', true),
 
-    /*
-    |--------------------------------------------------------------------------
-    | Field Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Configure which fields should be excluded from audit logging, and whether
-    | to include timestamps in the logged changes.
-    |
-    */
     'fields' => [
         'exclude' => [
             'password',
@@ -107,55 +50,42 @@ return [
             'trial_ends_at',
         ],
         'include_timestamps' => true,
+        'redact' => [],
+        'redaction_replacement' => env('AUDIT_REDACTION_REPLACEMENT', '[REDACTED]'),
+        'transformers' => [
+            // 'email' => \iamfarhad\LaravelAuditLog\Transformers\MaskEmailTransformer::class,
+            // 'phone' => \iamfarhad\LaravelAuditLog\Transformers\MaskValueTransformer::class,
+        ],
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Causer Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Configure how the system detects and records the causer of audit events.
-    | This is usually the authenticated user, but can be customized.
-    |
-    */
+    'security' => [
+        'hashing' => [
+            'enabled' => env('AUDIT_HASH_CHAIN_ENABLED', false),
+            'algorithm' => env('AUDIT_HASH_ALGORITHM', 'sha256'),
+            'key' => env('AUDIT_HASH_KEY', env('APP_KEY')),
+        ],
+    ],
+
     'causer' => [
-        'guard' => null, // null means use default guard
-        'model' => null, // null means auto-detect
-        'resolver' => null, // custom resolver class
+        'guard' => null,
+        'model' => null,
+        'resolver' => null,
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Retention Configuration
-    |--------------------------------------------------------------------------
-    |
-    | Configure automatic cleanup and retention policies for audit logs.
-    | You can set global defaults and override them per entity.
-    |
-    */
     'retention' => [
         'enabled' => env('AUDIT_RETENTION_ENABLED', false),
         'days' => env('AUDIT_RETENTION_DAYS', 365),
-        'strategy' => env('AUDIT_RETENTION_STRATEGY', 'delete'), // 'delete', 'archive', 'anonymize'
+        'strategy' => env('AUDIT_RETENTION_STRATEGY', 'delete'),
         'batch_size' => env('AUDIT_RETENTION_BATCH_SIZE', 1000),
         'anonymize_after_days' => env('AUDIT_ANONYMIZE_DAYS', 180),
         'archive_connection' => env('AUDIT_ARCHIVE_CONNECTION', null),
         'run_cleanup_automatically' => env('AUDIT_AUTO_CLEANUP', false),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Registered Entities
-    |--------------------------------------------------------------------------
-    |
-    | List of entities that should be audited. You can override retention
-    | settings per entity by adding a 'retention' key.
-    |
-    */
     'entities' => [
-        // Example:
         // \App\Models\User::class => [
         //     'table' => 'users',
+        //     'audit_table' => 'audit_users_logs',
         //     'exclude' => ['password'],
         //     'include' => ['*'],
         //     'retention' => [

--- a/docs/advanced-audit-features.md
+++ b/docs/advanced-audit-features.md
@@ -61,7 +61,68 @@ Use `restoreFromAudit()` for replaying a previous audited state and `rollbackToA
 
 ## Tamper-evident hash chain
 
-Enable hash-chain storage in `config/audit-logger.php` or `.env`:
+Hash-chain storage is disabled by default for backward compatibility. Enable it only after your existing audit tables have the required nullable columns.
+
+```env
+AUDIT_HASH_CHAIN_ENABLED=false
+```
+
+Add these columns to every existing audit table before enabling hash-chain storage:
+
+```php
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /** @var array<int, string> */
+    private array $tables = [
+        'audit_users_logs',
+        'audit_orders_logs',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $tableName) {
+            if (! Schema::hasTable($tableName)) {
+                continue;
+            }
+
+            Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+                if (! Schema::hasColumn($tableName, 'audit_hash')) {
+                    $table->string('audit_hash', 128)->nullable()->after('source')->index();
+                }
+
+                if (! Schema::hasColumn($tableName, 'previous_hash')) {
+                    $table->string('previous_hash', 128)->nullable()->after('audit_hash')->index();
+                }
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $tableName) {
+            if (! Schema::hasTable($tableName)) {
+                continue;
+            }
+
+            Schema::table($tableName, function (Blueprint $table) use ($tableName): void {
+                if (Schema::hasColumn($tableName, 'previous_hash')) {
+                    $table->dropColumn('previous_hash');
+                }
+
+                if (Schema::hasColumn($tableName, 'audit_hash')) {
+                    $table->dropColumn('audit_hash');
+                }
+            });
+        }
+    }
+};
+```
+
+Then enable hash-chain storage in `config/audit-logger.php` or `.env`:
 
 ```env
 AUDIT_HASH_CHAIN_ENABLED=true
@@ -69,10 +130,12 @@ AUDIT_HASH_ALGORITHM=sha256
 AUDIT_HASH_KEY=base64-or-secret-key
 ```
 
-When enabled, each audit row stores:
+When enabled, each new audit row stores:
 
 - `previous_hash`: the prior audit row hash for that audited entity table
 - `audit_hash`: an HMAC of the canonical audit payload plus `previous_hash`
+
+Rows created before hash-chain mode is enabled will not have historical hash values. Treat the first hashed row after enabling as the start of the verifiable chain.
 
 Verify a chain:
 
@@ -83,6 +146,8 @@ if (! $result['valid']) {
     report($result['failures']);
 }
 ```
+
+If the audit table or hash columns are missing, verification returns a structured failure with a `missing_audit_table` or `missing_hash_columns` code instead of throwing a database exception.
 
 ## Field redaction and transformers
 

--- a/docs/advanced-audit-features.md
+++ b/docs/advanced-audit-features.md
@@ -1,0 +1,153 @@
+# Advanced Audit Features
+
+This document covers the advanced APIs added for search, analytics, timelines, field-level diffs, tamper-evident audit chains, restore/replay workflows, and field redaction/transformers.
+
+## Audit search
+
+```php
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
+
+$logs = AuditLogger::search(App\Models\Order::class, 'approved')
+    ->forAction('updated')
+    ->between(now()->subMonth(), now())
+    ->latest()
+    ->paginate(50);
+```
+
+You can also build a query without a search term:
+
+```php
+$logs = AuditLogger::query(App\Models\Order::class)
+    ->forEntityId($order->id)
+    ->forCauser(App\Models\User::class, auth()->id())
+    ->get();
+```
+
+## Analytics
+
+```php
+$summary = AuditLogger::analytics()->summary(App\Models\Order::class);
+$topActions = AuditLogger::analytics()->topActions(App\Models\Order::class);
+$topCausers = AuditLogger::analytics()->topCausers(App\Models\Order::class);
+$changesPerDay = AuditLogger::analytics()->changesPerDay(App\Models\Order::class, 30);
+```
+
+## Timeline and diff API
+
+Audited models expose a presentation-friendly timeline and field-level diffs:
+
+```php
+$timeline = $order->auditTimeline();
+$latestDiff = $order->auditDiff();
+$specificDiff = $order->auditDiff($auditLogId);
+```
+
+Each timeline entry contains the action, entity id, causer, source, timestamp, metadata, hash values, and normalized field changes.
+
+## Restore, replay, and rollback
+
+```php
+// Apply the audit log's new values to the model.
+$order->restoreFromAudit($auditLogId);
+
+// Apply the audit log's old values to the model.
+$order->rollbackToAudit($auditLogId);
+
+// Preview without saving or mutating persistent state.
+$preview = $order->previewRestore($auditLogId, 'rollback');
+```
+
+Use `restoreFromAudit()` for replaying a previous audited state and `rollbackToAudit()` for reverting to the previous values captured by an update log.
+
+## Tamper-evident hash chain
+
+Enable hash-chain storage in `config/audit-logger.php` or `.env`:
+
+```env
+AUDIT_HASH_CHAIN_ENABLED=true
+AUDIT_HASH_ALGORITHM=sha256
+AUDIT_HASH_KEY=base64-or-secret-key
+```
+
+When enabled, each audit row stores:
+
+- `previous_hash`: the prior audit row hash for that audited entity table
+- `audit_hash`: an HMAC of the canonical audit payload plus `previous_hash`
+
+Verify a chain:
+
+```php
+$result = AuditLogger::verifyHashChain(App\Models\Order::class);
+
+if (! $result['valid']) {
+    report($result['failures']);
+}
+```
+
+## Field redaction and transformers
+
+Use redaction to replace sensitive values with a fixed placeholder:
+
+```php
+'fields' => [
+    'redact' => ['national_id', 'card_number'],
+    'redaction_replacement' => '[REDACTED]',
+],
+```
+
+Use transformers when the value should be masked, hashed, normalized, or formatted before it is stored:
+
+```php
+'fields' => [
+    'transformers' => [
+        'email' => \iamfarhad\LaravelAuditLog\Transformers\MaskEmailTransformer::class,
+        'phone' => \iamfarhad\LaravelAuditLog\Transformers\MaskValueTransformer::class,
+        'api_token' => \iamfarhad\LaravelAuditLog\Transformers\HashValueTransformer::class,
+    ],
+],
+```
+
+Custom transformers implement `FieldTransformerInterface`:
+
+```php
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use Illuminate\Database\Eloquent\Model;
+
+final class MoneyTransformer implements FieldTransformerInterface
+{
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed
+    {
+        return number_format((float) $value, 2, '.', '');
+    }
+}
+```
+
+## PostgreSQL support
+
+The package now resolves PostgreSQL consistently through both the service provider and `AuditLogger::getDriver()`:
+
+```php
+$logger = \iamfarhad\LaravelAuditLog\Services\AuditLogger::getDriver('postgresql');
+$logger = \iamfarhad\LaravelAuditLog\Services\AuditLogger::getDriver('pgsql');
+```
+
+PostgreSQL audit tables use `jsonb` for `old_values`, `new_values`, and `metadata`.
+
+## Comparison
+
+| Capability | Laravel Audit Logger | Spatie Activitylog | Laravel Auditing |
+|---|---:|---:|---:|
+| Entity-specific audit tables | Yes | No | No |
+| MySQL storage | Yes | Yes | Yes |
+| PostgreSQL storage | Yes | Via database support | Via database support |
+| Queue support | Yes | App-managed | App-managed |
+| Source tracking | Yes | Partial/manual | Resolver-based |
+| Audit search API | Yes | Query activity model | Query audit model |
+| Analytics helpers | Yes | No built-in analytics helper | No built-in analytics helper |
+| Timeline/diff API | Yes | Manual formatting | Auditable transition data |
+| Restore/replay API | Yes | No built-in model restore | Limited/manual workflows |
+| Tamper-evident hash chain | Yes | No | No |
+| Field redactors/transformers | Yes | Custom pipes/manual | Attribute modifiers/resolvers |
+| Retention strategies | Delete, anonymize, archive | Manual cleanup | Manual cleanup |
+
+The main positioning for this package is high-performance, compliance-ready model auditing with per-entity tables, source tracking, retention policies, and tamper-evident history.

--- a/src/AuditLoggerServiceProvider.php
+++ b/src/AuditLoggerServiceProvider.php
@@ -11,26 +11,25 @@ use iamfarhad\LaravelAuditLog\Contracts\RetentionServiceInterface;
 use iamfarhad\LaravelAuditLog\Drivers\MySQLDriver;
 use iamfarhad\LaravelAuditLog\Drivers\PostgreSQLDriver;
 use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditAnalytics;
+use iamfarhad\LaravelAuditLog\Services\AuditFieldTransformer;
+use iamfarhad\LaravelAuditLog\Services\AuditHash;
+use iamfarhad\LaravelAuditLog\Services\AuditHashVerifier;
 use iamfarhad\LaravelAuditLog\Services\AuditLogger;
+use iamfarhad\LaravelAuditLog\Services\AuditRestorer;
+use iamfarhad\LaravelAuditLog\Services\AuditTimeline;
 use iamfarhad\LaravelAuditLog\Services\CauserResolver;
 use iamfarhad\LaravelAuditLog\Services\RetentionService;
 use Illuminate\Support\ServiceProvider;
 
 final class AuditLoggerServiceProvider extends ServiceProvider
 {
-    /**
-     * Register services.
-     */
     public function register(): void
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/audit-logger.php',
-            'audit-logger'
-        );
+        $this->mergeConfigFrom(__DIR__.'/../config/audit-logger.php', 'audit-logger');
 
         $this->app->bind(AuditLogInterface::class, AuditLog::class);
 
-        // Register the causer resolver
         $this->app->singleton(
             CauserResolverInterface::class,
             fn ($app) => isset($app['config']['audit-logger.causer']['resolver']) && $app['config']['audit-logger.causer']['resolver']
@@ -41,41 +40,39 @@ final class AuditLoggerServiceProvider extends ServiceProvider
                 )
         );
 
-        // Register the main audit logger service - use fully qualified namespace
         $this->app->singleton(AuditLogger::class, function ($app) {
             $driverName = $app['config']['audit-logger.default'] ?? 'mysql';
             $connection = $app['config']["audit-logger.drivers.{$driverName}.connection"] ?? config('database.default');
 
             $driver = match ($driverName) {
                 'mysql' => new MySQLDriver($connection),
-                'postgresql' => new PostgreSQLDriver($connection),
-                default => new MySQLDriver($connection),
+                'postgresql', 'pgsql' => new PostgreSQLDriver($connection),
+                default => throw new \InvalidArgumentException("Driver {$driverName} not found"),
             };
 
             return new AuditLogger($driver);
         });
 
-        // Register the retention service
+        $this->app->alias(AuditLogger::class, 'audit-logger');
+        $this->app->singleton(AuditFieldTransformer::class);
+        $this->app->singleton(AuditHash::class);
+        $this->app->singleton(AuditHashVerifier::class);
+        $this->app->singleton(AuditAnalytics::class);
+        $this->app->singleton(AuditTimeline::class);
+        $this->app->singleton(AuditRestorer::class);
         $this->app->singleton(RetentionServiceInterface::class, RetentionService::class);
     }
 
-    /**
-     * Bootstrap services.
-     */
     public function boot(): void
     {
-        // Publish config
         if ($this->app->runningInConsole()) {
             $this->publishes([
                 __DIR__.'/../config/audit-logger.php' => config_path('audit-logger.php'),
             ], 'audit-logger-config');
 
-            // Register commands
             $this->commands([
                 CleanupAuditLogsCommand::class,
             ]);
         }
-
-        // Event listeners removed - using direct logging approach
     }
 }

--- a/src/Contracts/FieldTransformerInterface.php
+++ b/src/Contracts/FieldTransformerInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface FieldTransformerInterface
+{
+    /**
+     * Transform an audited field value before it is stored.
+     */
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed;
+}

--- a/src/Drivers/MySQLDriver.php
+++ b/src/Drivers/MySQLDriver.php
@@ -174,7 +174,13 @@ final class MySQLDriver implements AuditDriverInterface
     private function getTableName(string $entityType): string
     {
         $entityConfig = $this->config['entities'][$entityType] ?? [];
-        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural(Str::snake(class_basename($entityType)));
+        $configuredTable = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? null;
+
+        if (is_string($configuredTable) && $configuredTable !== '') {
+            return $configuredTable;
+        }
+
+        $tableName = Str::plural(Str::snake(class_basename($entityType)));
         if (! str_starts_with($tableName, $this->tablePrefix)) {
             $tableName = "{$this->tablePrefix}{$tableName}";
         }

--- a/src/Drivers/MySQLDriver.php
+++ b/src/Drivers/MySQLDriver.php
@@ -25,23 +25,12 @@ final class MySQLDriver implements AuditDriverInterface
 
     private static array $existingTables = [];
 
-    private static ?array $configCache = null;
-
     public function __construct(?string $connection = null)
     {
-        $this->config = self::getConfigCache();
+        $this->config = config('audit-logger');
         $this->connection = $connection ?? $this->config['drivers']['mysql']['connection'] ?? config('database.default');
         $this->tablePrefix = $this->config['drivers']['mysql']['table_prefix'] ?? 'audit_';
         $this->tableSuffix = $this->config['drivers']['mysql']['table_suffix'] ?? '_logs';
-    }
-
-    private static function getConfigCache(): array
-    {
-        if (self::$configCache === null) {
-            self::$configCache = config('audit-logger');
-        }
-
-        return self::$configCache;
     }
 
     private function validateEntityType(string $entityType): void
@@ -129,7 +118,6 @@ final class MySQLDriver implements AuditDriverInterface
     public static function clearCache(): void
     {
         self::$existingTables = [];
-        self::$configCache = null;
     }
 
     public static function clearTableCache(): void

--- a/src/Drivers/MySQLDriver.php
+++ b/src/Drivers/MySQLDriver.php
@@ -7,28 +7,19 @@ namespace iamfarhad\LaravelAuditLog\Drivers;
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditHash;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 final class MySQLDriver implements AuditDriverInterface
 {
     private string $tablePrefix;
-
     private string $tableSuffix;
-
     private array $config;
-
     private string $connection;
-
-    /**
-     * Cache for table existence checks to avoid repeated schema queries.
-     */
     private static array $existingTables = [];
-
-    /**
-     * Cache for configuration values to avoid repeated config() calls.
-     */
     private static ?array $configCache = null;
 
     public function __construct(?string $connection = null)
@@ -39,29 +30,19 @@ final class MySQLDriver implements AuditDriverInterface
         $this->tableSuffix = $this->config['drivers']['mysql']['table_suffix'] ?? '_logs';
     }
 
-    /**
-     * Get cached configuration to avoid repeated config() calls.
-     */
     private static function getConfigCache(): array
     {
         if (self::$configCache === null) {
             self::$configCache = config('audit-logger');
         }
-
         return self::$configCache;
     }
 
-    /**
-     * Validate that the entity type is a valid class.
-     * In testing environment, we allow fake class names for flexibility.
-     */
     private function validateEntityType(string $entityType): void
     {
-        // Skip validation in testing environment to allow fake class names
         if (app()->environment('testing')) {
             return;
         }
-
         if (! class_exists($entityType)) {
             throw new \InvalidArgumentException("Entity type '{$entityType}' is not a valid class.");
         }
@@ -70,70 +51,18 @@ final class MySQLDriver implements AuditDriverInterface
     public function store(AuditLogInterface $log): void
     {
         $this->validateEntityType($log->getEntityType());
-        $tableName = $this->getTableName($log->getEntityType());
-
         $this->ensureStorageExists($log->getEntityType());
-
-        try {
-            $model = EloquentAuditLog::forEntity(entityClass: $log->getEntityType());
-            $model->setConnection($this->connection);
-            $model->fill([
-                'entity_id' => $log->getEntityId(),
-                'action' => $log->getAction(),
-                'old_values' => $log->getOldValues(), // Remove manual json_encode - let Eloquent handle it
-                'new_values' => $log->getNewValues(), // Remove manual json_encode - let Eloquent handle it
-                'causer_type' => $log->getCauserType(),
-                'causer_id' => $log->getCauserId(),
-                'metadata' => $log->getMetadata(), // Remove manual json_encode - let Eloquent handle it
-                'created_at' => $log->getCreatedAt(),
-                'source' => $log->getSource(),
-            ]);
-            $model->save();
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $model = EloquentAuditLog::forEntity(entityClass: $log->getEntityType());
+        $model->setConnection($this->connection);
+        $model->fill($this->payloadForLog($log));
+        $model->save();
     }
 
-    /**
-     * Store multiple audit logs using Eloquent models with proper casting.
-     *
-     * @param  array<AuditLogInterface>  $logs
-     */
+    /** @param array<AuditLogInterface> $logs */
     public function storeBatch(array $logs): void
     {
-        if (empty($logs)) {
-            return;
-        }
-
-        // Group logs by entity type (and thus by table)
-        $groupedLogs = [];
         foreach ($logs as $log) {
-            $this->validateEntityType($log->getEntityType());
-            $entityType = $log->getEntityType();
-            $groupedLogs[$entityType][] = $log;
-        }
-
-        // Process each entity type separately using Eloquent models to leverage casting
-        foreach ($groupedLogs as $entityType => $entityLogs) {
-            $this->ensureStorageExists($entityType);
-
-            // Use Eloquent models to leverage automatic JSON casting
-            foreach ($entityLogs as $log) {
-                $model = EloquentAuditLog::forEntity(entityClass: $entityType);
-                $model->setConnection($this->connection);
-                $model->fill([
-                    'entity_id' => $log->getEntityId(),
-                    'action' => $log->getAction(),
-                    'old_values' => $log->getOldValues(), // Eloquent casting handles JSON encoding
-                    'new_values' => $log->getNewValues(), // Eloquent casting handles JSON encoding
-                    'causer_type' => $log->getCauserType(),
-                    'causer_id' => $log->getCauserId(),
-                    'metadata' => $log->getMetadata(), // Eloquent casting handles JSON encoding
-                    'created_at' => $log->getCreatedAt(),
-                    'source' => $log->getSource(),
-                ]);
-                $model->save();
-            }
+            $this->store($log);
         }
     }
 
@@ -141,7 +70,6 @@ final class MySQLDriver implements AuditDriverInterface
     {
         $this->validateEntityType($entityClass);
         $tableName = $this->getTableName($entityClass);
-
         Schema::connection($this->connection)->create($tableName, function (Blueprint $table) {
             $table->id();
             $table->string('entity_id');
@@ -153,83 +81,97 @@ final class MySQLDriver implements AuditDriverInterface
             $table->json('metadata')->nullable();
             $table->timestamp('created_at');
             $table->string('source')->nullable();
+            $table->string('audit_hash', 128)->nullable();
+            $table->string('previous_hash', 128)->nullable();
             $table->timestamp('anonymized_at')->nullable();
-
-            // Basic indexes
             $table->index('entity_id');
             $table->index('causer_id');
             $table->index('created_at');
             $table->index('action');
+            $table->index('source');
+            $table->index('audit_hash');
+            $table->index('previous_hash');
             $table->index('anonymized_at');
-
-            // Composite indexes for common query patterns
             $table->index(['entity_id', 'action']);
             $table->index(['entity_id', 'created_at']);
             $table->index(['causer_id', 'action']);
             $table->index(['action', 'created_at']);
         });
-
-        // Cache the newly created table
         self::$existingTables[$tableName] = true;
     }
 
     public function storageExistsForEntity(string $entityClass): bool
     {
         $tableName = $this->getTableName($entityClass);
-
-        // Check cache first to avoid repeated schema queries
         if (isset(self::$existingTables[$tableName])) {
             return self::$existingTables[$tableName];
         }
-
-        // Check database and cache the result
-        $exists = Schema::connection($this->connection)->hasTable($tableName);
-        self::$existingTables[$tableName] = $exists;
-
-        return $exists;
+        return self::$existingTables[$tableName] = Schema::connection($this->connection)->hasTable($tableName);
     }
 
-    /**
-     * Ensures the audit storage exists for the entity if auto_migration is enabled.
-     */
     public function ensureStorageExists(string $entityClass): void
     {
-        $autoMigration = $this->config['auto_migration'] ?? true;
-        if ($autoMigration === false) {
+        if (($this->config['auto_migration'] ?? true) === false) {
             return;
         }
-
         if (! $this->storageExistsForEntity($entityClass)) {
             $this->createStorageForEntity($entityClass);
         }
     }
 
-    /**
-     * Clear the table existence cache and config cache.
-     * Useful for testing or when tables are dropped/recreated.
-     */
     public static function clearCache(): void
     {
         self::$existingTables = [];
         self::$configCache = null;
     }
 
-    /**
-     * Clear only the table existence cache.
-     */
     public static function clearTableCache(): void
     {
         self::$existingTables = [];
     }
 
+    private function payloadForLog(AuditLogInterface $log): array
+    {
+        $payload = [
+            'entity_id' => $log->getEntityId(),
+            'action' => $log->getAction(),
+            'old_values' => $log->getOldValues(),
+            'new_values' => $log->getNewValues(),
+            'causer_type' => $log->getCauserType(),
+            'causer_id' => $log->getCauserId(),
+            'metadata' => $log->getMetadata(),
+            'created_at' => $log->getCreatedAt(),
+            'source' => $log->getSource(),
+        ];
+        $hash = app(AuditHash::class);
+        if ($hash->enabled()) {
+            $previousHash = $this->latestHashForEntity($log->getEntityType());
+            $payload['previous_hash'] = $previousHash;
+            $payload['audit_hash'] = $hash->compute($log, $previousHash);
+        }
+        return $payload;
+    }
+
+    private function latestHashForEntity(string $entityType): ?string
+    {
+        $value = DB::connection($this->connection)
+            ->table($this->getTableName($entityType))
+            ->whereNotNull('audit_hash')
+            ->orderByDesc('id')
+            ->value('audit_hash');
+        return is_string($value) ? $value : null;
+    }
+
     private function getTableName(string $entityType): string
     {
-        // Extract class name without namespace
-        $className = Str::snake(class_basename($entityType));
-
-        // Handle pluralization
-        $tableName = Str::plural($className);
-
-        return "{$this->tablePrefix}{$tableName}{$this->tableSuffix}";
+        $entityConfig = $this->config['entities'][$entityType] ?? [];
+        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural(Str::snake(class_basename($entityType)));
+        if (! str_starts_with($tableName, $this->tablePrefix)) {
+            $tableName = "{$this->tablePrefix}{$tableName}";
+        }
+        if (! str_ends_with($tableName, $this->tableSuffix)) {
+            $tableName = "{$tableName}{$this->tableSuffix}";
+        }
+        return $tableName;
     }
 }

--- a/src/Drivers/MySQLDriver.php
+++ b/src/Drivers/MySQLDriver.php
@@ -16,10 +16,15 @@ use Illuminate\Support\Str;
 final class MySQLDriver implements AuditDriverInterface
 {
     private string $tablePrefix;
+
     private string $tableSuffix;
+
     private array $config;
+
     private string $connection;
+
     private static array $existingTables = [];
+
     private static ?array $configCache = null;
 
     public function __construct(?string $connection = null)
@@ -35,6 +40,7 @@ final class MySQLDriver implements AuditDriverInterface
         if (self::$configCache === null) {
             self::$configCache = config('audit-logger');
         }
+
         return self::$configCache;
     }
 
@@ -106,6 +112,7 @@ final class MySQLDriver implements AuditDriverInterface
         if (isset(self::$existingTables[$tableName])) {
             return self::$existingTables[$tableName];
         }
+
         return self::$existingTables[$tableName] = Schema::connection($this->connection)->hasTable($tableName);
     }
 
@@ -149,6 +156,7 @@ final class MySQLDriver implements AuditDriverInterface
             $payload['previous_hash'] = $previousHash;
             $payload['audit_hash'] = $hash->compute($log, $previousHash);
         }
+
         return $payload;
     }
 
@@ -159,6 +167,7 @@ final class MySQLDriver implements AuditDriverInterface
             ->whereNotNull('audit_hash')
             ->orderByDesc('id')
             ->value('audit_hash');
+
         return is_string($value) ? $value : null;
     }
 
@@ -172,6 +181,7 @@ final class MySQLDriver implements AuditDriverInterface
         if (! str_ends_with($tableName, $this->tableSuffix)) {
             $tableName = "{$tableName}{$this->tableSuffix}";
         }
+
         return $tableName;
     }
 }

--- a/src/Drivers/PostgreSQLDriver.php
+++ b/src/Drivers/PostgreSQLDriver.php
@@ -174,7 +174,13 @@ final class PostgreSQLDriver implements AuditDriverInterface
     private function getTableName(string $entityType): string
     {
         $entityConfig = $this->config['entities'][$entityType] ?? [];
-        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural(Str::snake(class_basename($entityType)));
+        $configuredTable = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? null;
+
+        if (is_string($configuredTable) && $configuredTable !== '') {
+            return $configuredTable;
+        }
+
+        $tableName = Str::plural(Str::snake(class_basename($entityType)));
         if (! str_starts_with($tableName, $this->tablePrefix)) {
             $tableName = "{$this->tablePrefix}{$tableName}";
         }

--- a/src/Drivers/PostgreSQLDriver.php
+++ b/src/Drivers/PostgreSQLDriver.php
@@ -7,28 +7,19 @@ namespace iamfarhad\LaravelAuditLog\Drivers;
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditHash;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
 
 final class PostgreSQLDriver implements AuditDriverInterface
 {
     private string $tablePrefix;
-
     private string $tableSuffix;
-
     private array $config;
-
     private string $connection;
-
-    /**
-     * Cache for table existence checks to avoid repeated schema queries.
-     */
     private static array $existingTables = [];
-
-    /**
-     * Cache for configuration values to avoid repeated config() calls.
-     */
     private static ?array $configCache = null;
 
     public function __construct(?string $connection = null)
@@ -39,29 +30,19 @@ final class PostgreSQLDriver implements AuditDriverInterface
         $this->tableSuffix = $this->config['drivers']['postgresql']['table_suffix'] ?? '_logs';
     }
 
-    /**
-     * Get cached configuration to avoid repeated config() calls.
-     */
     private static function getConfigCache(): array
     {
         if (self::$configCache === null) {
             self::$configCache = config('audit-logger');
         }
-
         return self::$configCache;
     }
 
-    /**
-     * Validate that the entity type is a valid class.
-     * In testing environment, we allow fake class names for flexibility.
-     */
     private function validateEntityType(string $entityType): void
     {
-        // Skip validation in testing environment to allow fake class names
         if (app()->environment('testing')) {
             return;
         }
-
         if (! class_exists($entityType)) {
             throw new \InvalidArgumentException("Entity type '{$entityType}' is not a valid class.");
         }
@@ -70,70 +51,18 @@ final class PostgreSQLDriver implements AuditDriverInterface
     public function store(AuditLogInterface $log): void
     {
         $this->validateEntityType($log->getEntityType());
-        $tableName = $this->getTableName($log->getEntityType());
-
         $this->ensureStorageExists($log->getEntityType());
-
-        try {
-            $model = EloquentAuditLog::forEntity(entityClass: $log->getEntityType());
-            $model->setConnection($this->connection);
-            $model->fill([
-                'entity_id' => $log->getEntityId(),
-                'action' => $log->getAction(),
-                'old_values' => $log->getOldValues(), // Remove manual json_encode - let Eloquent handle it
-                'new_values' => $log->getNewValues(), // Remove manual json_encode - let Eloquent handle it
-                'causer_type' => $log->getCauserType(),
-                'causer_id' => $log->getCauserId(),
-                'metadata' => $log->getMetadata(), // Remove manual json_encode - let Eloquent handle it
-                'created_at' => $log->getCreatedAt(),
-                'source' => $log->getSource(),
-            ]);
-            $model->save();
-        } catch (\Exception $e) {
-            throw $e;
-        }
+        $model = EloquentAuditLog::forEntity(entityClass: $log->getEntityType());
+        $model->setConnection($this->connection);
+        $model->fill($this->payloadForLog($log));
+        $model->save();
     }
 
-    /**
-     * Store multiple audit logs using Eloquent models with proper casting.
-     *
-     * @param  array<AuditLogInterface>  $logs
-     */
+    /** @param array<AuditLogInterface> $logs */
     public function storeBatch(array $logs): void
     {
-        if (empty($logs)) {
-            return;
-        }
-
-        // Group logs by entity type (and thus by table)
-        $groupedLogs = [];
         foreach ($logs as $log) {
-            $this->validateEntityType($log->getEntityType());
-            $entityType = $log->getEntityType();
-            $groupedLogs[$entityType][] = $log;
-        }
-
-        // Process each entity type separately using Eloquent models to leverage casting
-        foreach ($groupedLogs as $entityType => $entityLogs) {
-            $this->ensureStorageExists($entityType);
-
-            // Use Eloquent models to leverage automatic JSON casting
-            foreach ($entityLogs as $log) {
-                $model = EloquentAuditLog::forEntity(entityClass: $entityType);
-                $model->setConnection($this->connection);
-                $model->fill([
-                    'entity_id' => $log->getEntityId(),
-                    'action' => $log->getAction(),
-                    'old_values' => $log->getOldValues(), // Eloquent casting handles JSON encoding
-                    'new_values' => $log->getNewValues(), // Eloquent casting handles JSON encoding
-                    'causer_type' => $log->getCauserType(),
-                    'causer_id' => $log->getCauserId(),
-                    'metadata' => $log->getMetadata(), // Eloquent casting handles JSON encoding
-                    'created_at' => $log->getCreatedAt(),
-                    'source' => $log->getSource(),
-                ]);
-                $model->save();
-            }
+            $this->store($log);
         }
     }
 
@@ -141,12 +70,10 @@ final class PostgreSQLDriver implements AuditDriverInterface
     {
         $this->validateEntityType($entityClass);
         $tableName = $this->getTableName($entityClass);
-
         Schema::connection($this->connection)->create($tableName, function (Blueprint $table) {
             $table->id();
             $table->string('entity_id');
             $table->string('action');
-            // PostgreSQL supports both json and jsonb. Using jsonb for better performance
             $table->jsonb('old_values')->nullable();
             $table->jsonb('new_values')->nullable();
             $table->string('causer_type')->nullable();
@@ -154,83 +81,97 @@ final class PostgreSQLDriver implements AuditDriverInterface
             $table->jsonb('metadata')->nullable();
             $table->timestamp('created_at');
             $table->string('source')->nullable();
+            $table->string('audit_hash', 128)->nullable();
+            $table->string('previous_hash', 128)->nullable();
             $table->timestamp('anonymized_at')->nullable();
-
-            // Basic indexes
             $table->index('entity_id');
             $table->index('causer_id');
             $table->index('created_at');
             $table->index('action');
+            $table->index('source');
+            $table->index('audit_hash');
+            $table->index('previous_hash');
             $table->index('anonymized_at');
-
-            // Composite indexes for common query patterns
             $table->index(['entity_id', 'action']);
             $table->index(['entity_id', 'created_at']);
             $table->index(['causer_id', 'action']);
             $table->index(['action', 'created_at']);
         });
-
-        // Cache the newly created table
         self::$existingTables[$tableName] = true;
     }
 
     public function storageExistsForEntity(string $entityClass): bool
     {
         $tableName = $this->getTableName($entityClass);
-
-        // Check cache first to avoid repeated schema queries
         if (isset(self::$existingTables[$tableName])) {
             return self::$existingTables[$tableName];
         }
-
-        // Check database and cache the result
-        $exists = Schema::connection($this->connection)->hasTable($tableName);
-        self::$existingTables[$tableName] = $exists;
-
-        return $exists;
+        return self::$existingTables[$tableName] = Schema::connection($this->connection)->hasTable($tableName);
     }
 
-    /**
-     * Ensures the audit storage exists for the entity if auto_migration is enabled.
-     */
     public function ensureStorageExists(string $entityClass): void
     {
-        $autoMigration = $this->config['auto_migration'] ?? true;
-        if ($autoMigration === false) {
+        if (($this->config['auto_migration'] ?? true) === false) {
             return;
         }
-
         if (! $this->storageExistsForEntity($entityClass)) {
             $this->createStorageForEntity($entityClass);
         }
     }
 
-    /**
-     * Clear the table existence cache and config cache.
-     * Useful for testing or when tables are dropped/recreated.
-     */
     public static function clearCache(): void
     {
         self::$existingTables = [];
         self::$configCache = null;
     }
 
-    /**
-     * Clear only the table existence cache.
-     */
     public static function clearTableCache(): void
     {
         self::$existingTables = [];
     }
 
+    private function payloadForLog(AuditLogInterface $log): array
+    {
+        $payload = [
+            'entity_id' => $log->getEntityId(),
+            'action' => $log->getAction(),
+            'old_values' => $log->getOldValues(),
+            'new_values' => $log->getNewValues(),
+            'causer_type' => $log->getCauserType(),
+            'causer_id' => $log->getCauserId(),
+            'metadata' => $log->getMetadata(),
+            'created_at' => $log->getCreatedAt(),
+            'source' => $log->getSource(),
+        ];
+        $hash = app(AuditHash::class);
+        if ($hash->enabled()) {
+            $previousHash = $this->latestHashForEntity($log->getEntityType());
+            $payload['previous_hash'] = $previousHash;
+            $payload['audit_hash'] = $hash->compute($log, $previousHash);
+        }
+        return $payload;
+    }
+
+    private function latestHashForEntity(string $entityType): ?string
+    {
+        $value = DB::connection($this->connection)
+            ->table($this->getTableName($entityType))
+            ->whereNotNull('audit_hash')
+            ->orderByDesc('id')
+            ->value('audit_hash');
+        return is_string($value) ? $value : null;
+    }
+
     private function getTableName(string $entityType): string
     {
-        // Extract class name without namespace
-        $className = Str::snake(class_basename($entityType));
-
-        // Handle pluralization
-        $tableName = Str::plural($className);
-
-        return "{$this->tablePrefix}{$tableName}{$this->tableSuffix}";
+        $entityConfig = $this->config['entities'][$entityType] ?? [];
+        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural(Str::snake(class_basename($entityType)));
+        if (! str_starts_with($tableName, $this->tablePrefix)) {
+            $tableName = "{$this->tablePrefix}{$tableName}";
+        }
+        if (! str_ends_with($tableName, $this->tableSuffix)) {
+            $tableName = "{$tableName}{$this->tableSuffix}";
+        }
+        return $tableName;
     }
 }

--- a/src/Drivers/PostgreSQLDriver.php
+++ b/src/Drivers/PostgreSQLDriver.php
@@ -25,23 +25,12 @@ final class PostgreSQLDriver implements AuditDriverInterface
 
     private static array $existingTables = [];
 
-    private static ?array $configCache = null;
-
     public function __construct(?string $connection = null)
     {
-        $this->config = self::getConfigCache();
+        $this->config = config('audit-logger');
         $this->connection = $connection ?? $this->config['drivers']['postgresql']['connection'] ?? config('database.default');
         $this->tablePrefix = $this->config['drivers']['postgresql']['table_prefix'] ?? 'audit_';
         $this->tableSuffix = $this->config['drivers']['postgresql']['table_suffix'] ?? '_logs';
-    }
-
-    private static function getConfigCache(): array
-    {
-        if (self::$configCache === null) {
-            self::$configCache = config('audit-logger');
-        }
-
-        return self::$configCache;
     }
 
     private function validateEntityType(string $entityType): void
@@ -129,7 +118,6 @@ final class PostgreSQLDriver implements AuditDriverInterface
     public static function clearCache(): void
     {
         self::$existingTables = [];
-        self::$configCache = null;
     }
 
     public static function clearTableCache(): void

--- a/src/Drivers/PostgreSQLDriver.php
+++ b/src/Drivers/PostgreSQLDriver.php
@@ -16,10 +16,15 @@ use Illuminate\Support\Str;
 final class PostgreSQLDriver implements AuditDriverInterface
 {
     private string $tablePrefix;
+
     private string $tableSuffix;
+
     private array $config;
+
     private string $connection;
+
     private static array $existingTables = [];
+
     private static ?array $configCache = null;
 
     public function __construct(?string $connection = null)
@@ -35,6 +40,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
         if (self::$configCache === null) {
             self::$configCache = config('audit-logger');
         }
+
         return self::$configCache;
     }
 
@@ -106,6 +112,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
         if (isset(self::$existingTables[$tableName])) {
             return self::$existingTables[$tableName];
         }
+
         return self::$existingTables[$tableName] = Schema::connection($this->connection)->hasTable($tableName);
     }
 
@@ -149,6 +156,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
             $payload['previous_hash'] = $previousHash;
             $payload['audit_hash'] = $hash->compute($log, $previousHash);
         }
+
         return $payload;
     }
 
@@ -159,6 +167,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
             ->whereNotNull('audit_hash')
             ->orderByDesc('id')
             ->value('audit_hash');
+
         return is_string($value) ? $value : null;
     }
 
@@ -172,6 +181,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
         if (! str_ends_with($tableName, $this->tableSuffix)) {
             $tableName = "{$tableName}{$this->tableSuffix}";
         }
+
         return $tableName;
     }
 }

--- a/src/Models/EloquentAuditLog.php
+++ b/src/Models/EloquentAuditLog.php
@@ -10,8 +10,6 @@ use Illuminate\Support\Str;
 
 final class EloquentAuditLog extends Model
 {
-    private static ?array $configCache = null;
-
     public $timestamps = false;
 
     protected $fillable = [
@@ -32,12 +30,11 @@ final class EloquentAuditLog extends Model
         'old_values' => 'json',
         'new_values' => 'json',
         'metadata' => 'array',
-        'created_at' => 'datetime',
     ];
 
     public function getConnectionName(): ?string
     {
-        $config = self::getConfigCache();
+        $config = config('audit-logger');
         $driverName = $config['default'] ?? 'mysql';
 
         return $config['drivers'][$driverName]['connection'] ?? config('database.default');
@@ -95,7 +92,7 @@ final class EloquentAuditLog extends Model
 
     public function scopeDateBetween(Builder $query, $startDate, $endDate): Builder
     {
-        return $query->where(function (Builder $query) use ($startDate, $endDate) {
+        return $query->where(function (Builder $query) use ($startDate, $endDate): void {
             $query->where('created_at', '>=', $startDate)
                 ->where('created_at', '<=', $endDate);
         });
@@ -133,7 +130,7 @@ final class EloquentAuditLog extends Model
 
     public function scopeFromHttp(Builder $query): Builder
     {
-        return $query->where(function (Builder $query) {
+        return $query->where(function (Builder $query): void {
             $query->where('source', 'like', 'App\\Http\\Controllers\\%')
                 ->orWhere('source', 'like', 'App\\\\Http\\\\Controllers\\\\%')
                 ->orWhere('source', '=', 'http');
@@ -153,24 +150,15 @@ final class EloquentAuditLog extends Model
             return $query->where('source', 'like', "%{$escapedController}%");
         }
 
-        return $query->where(function (Builder $query) {
+        return $query->where(function (Builder $query): void {
             $query->where('source', 'like', 'App\\Http\\Controllers\\%')
                 ->orWhere('source', 'like', 'App\\\\Http\\\\Controllers\\\\%');
         });
     }
 
-    private static function getConfigCache(): array
-    {
-        if (self::$configCache === null) {
-            self::$configCache = config('audit-logger');
-        }
-
-        return self::$configCache;
-    }
-
     public static function forEntity(string $entityClass): static
     {
-        $config = self::getConfigCache();
+        $config = config('audit-logger');
         $driverName = $config['default'] ?? 'mysql';
         $driverConfig = $config['drivers'][$driverName] ?? $config['drivers']['mysql'] ?? [];
         $entityConfig = $config['entities'][$entityClass] ?? [];

--- a/src/Models/EloquentAuditLog.php
+++ b/src/Models/EloquentAuditLog.php
@@ -6,6 +6,7 @@ namespace iamfarhad\LaravelAuditLog\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 final class EloquentAuditLog extends Model
@@ -106,16 +107,23 @@ final class EloquentAuditLog extends Model
     public function scopeSearch(Builder $query, string $term): Builder
     {
         $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
+        $jsonColumns = ['old_values', 'new_values', 'metadata'];
+        $isPostgreSQL = $query->getModel()->getConnection()->getDriverName() === 'pgsql';
 
-        return $query->where(function (Builder $query) use ($like): void {
+        return $query->where(function (Builder $query) use ($isPostgreSQL, $jsonColumns, $like): void {
             $query->where('entity_id', 'like', $like)
                 ->orWhere('action', 'like', $like)
                 ->orWhere('source', 'like', $like)
                 ->orWhere('causer_type', 'like', $like)
-                ->orWhere('causer_id', 'like', $like)
-                ->orWhere('old_values', 'like', $like)
-                ->orWhere('new_values', 'like', $like)
-                ->orWhere('metadata', 'like', $like);
+                ->orWhere('causer_id', 'like', $like);
+
+            foreach ($jsonColumns as $column) {
+                if ($isPostgreSQL) {
+                    $query->orWhereRaw(DB::getQueryGrammar()->wrap($column).'::text LIKE ?', [$like]);
+                } else {
+                    $query->orWhere($column, 'like', $like);
+                }
+            }
         });
     }
 
@@ -162,17 +170,12 @@ final class EloquentAuditLog extends Model
         $driverName = $config['default'] ?? 'mysql';
         $driverConfig = $config['drivers'][$driverName] ?? $config['drivers']['mysql'] ?? [];
         $entityConfig = $config['entities'][$entityClass] ?? [];
-        $className = Str::snake(class_basename($entityClass));
-        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural($className);
-        $tablePrefix = $driverConfig['table_prefix'] ?? 'audit_';
-        $tableSuffix = $driverConfig['table_suffix'] ?? '_logs';
+        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? null;
 
-        if (! str_starts_with($tableName, $tablePrefix)) {
-            $tableName = "{$tablePrefix}{$tableName}";
-        }
-
-        if (! str_ends_with($tableName, $tableSuffix)) {
-            $tableName = "{$tableName}{$tableSuffix}";
+        if ($tableName === null) {
+            $tablePrefix = $driverConfig['table_prefix'] ?? 'audit_';
+            $tableSuffix = $driverConfig['table_suffix'] ?? '_logs';
+            $tableName = $tablePrefix.Str::plural(Str::snake(class_basename($entityClass))).$tableSuffix;
         }
 
         $instance = new self;

--- a/src/Models/EloquentAuditLog.php
+++ b/src/Models/EloquentAuditLog.php
@@ -6,7 +6,6 @@ namespace iamfarhad\LaravelAuditLog\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 final class EloquentAuditLog extends Model
@@ -108,9 +107,11 @@ final class EloquentAuditLog extends Model
     {
         $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
         $jsonColumns = ['old_values', 'new_values', 'metadata'];
-        $isPostgreSQL = $query->getModel()->getConnection()->getDriverName() === 'pgsql';
+        $connection = $query->getModel()->getConnection();
+        $grammar = $connection->getQueryGrammar();
+        $isPostgreSQL = $connection->getDriverName() === 'pgsql';
 
-        return $query->where(function (Builder $query) use ($isPostgreSQL, $jsonColumns, $like): void {
+        return $query->where(function (Builder $query) use ($grammar, $isPostgreSQL, $jsonColumns, $like): void {
             $query->where('entity_id', 'like', $like)
                 ->orWhere('action', 'like', $like)
                 ->orWhere('source', 'like', $like)
@@ -119,7 +120,7 @@ final class EloquentAuditLog extends Model
 
             foreach ($jsonColumns as $column) {
                 if ($isPostgreSQL) {
-                    $query->orWhereRaw(DB::getQueryGrammar()->wrap($column).'::text LIKE ?', [$like]);
+                    $query->orWhereRaw($grammar->wrap($column).'::text LIKE ?', [$like]);
                 } else {
                     $query->orWhere($column, 'like', $like);
                 }

--- a/src/Models/EloquentAuditLog.php
+++ b/src/Models/EloquentAuditLog.php
@@ -10,24 +10,10 @@ use Illuminate\Support\Str;
 
 final class EloquentAuditLog extends Model
 {
-    /**
-     * Cache for configuration values to avoid repeated config() calls.
-     */
     private static ?array $configCache = null;
 
-    /**
-     * Indicates if the model should be timestamped.
-     * We handle the created_at timestamp manually.
-     *
-     * @var bool
-     */
     public $timestamps = false;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array<int, string>
-     */
     protected $fillable = [
         'entity_id',
         'action',
@@ -38,22 +24,23 @@ final class EloquentAuditLog extends Model
         'metadata',
         'created_at',
         'source',
+        'audit_hash',
+        'previous_hash',
     ];
 
     protected $casts = [
         'old_values' => 'json',
         'new_values' => 'json',
         'metadata' => 'array',
+        'created_at' => 'datetime',
     ];
 
-    /**
-     * Get the connection name for the model.
-     */
     public function getConnectionName(): ?string
     {
         $config = self::getConfigCache();
+        $driverName = $config['default'] ?? 'mysql';
 
-        return $config['drivers']['mysql']['connection'] ?? config('database.default');
+        return $config['drivers'][$driverName]['connection'] ?? config('database.default');
     }
 
     public function auditable()
@@ -68,7 +55,7 @@ final class EloquentAuditLog extends Model
 
     public function scopeForEntity(Builder $query, $entityClass): Builder
     {
-        return $query->where('entity_type', $entityClass);
+        return $query;
     }
 
     public function scopeForEntityId(Builder $query, $entityId): Builder
@@ -78,7 +65,7 @@ final class EloquentAuditLog extends Model
 
     public function scopeForAction(Builder $query, $action): Builder
     {
-        return $query->where('action', $action);
+        return is_array($action) ? $query->whereIn('action', $action) : $query->where('action', $action);
     }
 
     public function scopeForCauser(Builder $query, $causerClass): Builder
@@ -119,9 +106,24 @@ final class EloquentAuditLog extends Model
         return $query->where('source', $source);
     }
 
+    public function scopeSearch(Builder $query, string $term): Builder
+    {
+        $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
+
+        return $query->where(function (Builder $query) use ($like): void {
+            $query->where('entity_id', 'like', $like)
+                ->orWhere('action', 'like', $like)
+                ->orWhere('source', 'like', $like)
+                ->orWhere('causer_type', 'like', $like)
+                ->orWhere('causer_id', 'like', $like)
+                ->orWhere('old_values', 'like', $like)
+                ->orWhere('new_values', 'like', $like)
+                ->orWhere('metadata', 'like', $like);
+        });
+    }
+
     public function scopeFromConsole(Builder $query): Builder
     {
-        /** @var Builder $query */
         $query->whereNotNull('source');
         $query->where('source', 'not like', 'App\\Http\\Controllers\\%');
         $query->where('source', 'not like', 'App\\\\Http\\\\Controllers\\\\%');
@@ -146,7 +148,6 @@ final class EloquentAuditLog extends Model
     public function scopeFromController(Builder $query, ?string $controller = null): Builder
     {
         if ($controller !== null && $controller !== '') {
-            // Escape the controller string to prevent SQL injection
             $escapedController = str_replace(['%', '_'], ['\\%', '\\_'], $controller);
 
             return $query->where('source', 'like', "%{$escapedController}%");
@@ -158,9 +159,6 @@ final class EloquentAuditLog extends Model
         });
     }
 
-    /**
-     * Get cached configuration to avoid repeated config() calls.
-     */
     private static function getConfigCache(): array
     {
         if (self::$configCache === null) {
@@ -172,22 +170,27 @@ final class EloquentAuditLog extends Model
 
     public static function forEntity(string $entityClass): static
     {
-        $className = Str::snake(class_basename($entityClass));
-
-        // Handle pluralization
-        $tableName = Str::plural($className);
-
         $config = self::getConfigCache();
-        $tablePrefix = $config['drivers']['mysql']['table_prefix'] ?? 'audit_';
-        $tableSuffix = $config['drivers']['mysql']['table_suffix'] ?? '_logs';
+        $driverName = $config['default'] ?? 'mysql';
+        $driverConfig = $config['drivers'][$driverName] ?? $config['drivers']['mysql'] ?? [];
+        $entityConfig = $config['entities'][$entityClass] ?? [];
+        $className = Str::snake(class_basename($entityClass));
+        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? Str::plural($className);
+        $tablePrefix = $driverConfig['table_prefix'] ?? 'audit_';
+        $tableSuffix = $driverConfig['table_suffix'] ?? '_logs';
 
-        $table = "{$tablePrefix}{$tableName}{$tableSuffix}";
+        if (! str_starts_with($tableName, $tablePrefix)) {
+            $tableName = "{$tablePrefix}{$tableName}";
+        }
+
+        if (! str_ends_with($tableName, $tableSuffix)) {
+            $tableName = "{$tableName}{$tableSuffix}";
+        }
 
         $instance = new self;
-        $instance->setTable($table);
+        $instance->setTable($tableName);
 
-        // Set the connection from config
-        $connection = $config['drivers']['mysql']['connection'] ?? config('database.default');
+        $connection = $driverConfig['connection'] ?? config('database.default');
         if ($connection) {
             $instance->setConnection($connection);
         }

--- a/src/Services/AuditAnalytics.php
+++ b/src/Services/AuditAnalytics.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+final class AuditAnalytics
+{
+    /** @return array<string, mixed> */
+    public function summary(string $entityClass): array
+    {
+        $query = EloquentAuditLog::forEntity($entityClass)->newQuery();
+
+        return [
+            'total' => (clone $query)->count(),
+            'first_audit_at' => (clone $query)->min('created_at'),
+            'last_audit_at' => (clone $query)->max('created_at'),
+            'actions' => $this->topActions($entityClass)->pluck('count', 'action')->all(),
+        ];
+    }
+
+    /** @return Collection<int, object> */
+    public function topActions(string $entityClass, int $limit = 10): Collection
+    {
+        return EloquentAuditLog::forEntity($entityClass)
+            ->newQuery()
+            ->select('action', DB::raw('COUNT(*) as count'))
+            ->groupBy('action')
+            ->orderByDesc('count')
+            ->limit($limit)
+            ->get();
+    }
+
+    /** @return Collection<int, object> */
+    public function topCausers(string $entityClass, int $limit = 10): Collection
+    {
+        return EloquentAuditLog::forEntity($entityClass)
+            ->newQuery()
+            ->select('causer_type', 'causer_id', DB::raw('COUNT(*) as count'))
+            ->whereNotNull('causer_id')
+            ->groupBy('causer_type', 'causer_id')
+            ->orderByDesc('count')
+            ->limit($limit)
+            ->get();
+    }
+
+    /** @return Collection<int, object> */
+    public function topChangedEntities(string $entityClass, int $limit = 10): Collection
+    {
+        return EloquentAuditLog::forEntity($entityClass)
+            ->newQuery()
+            ->select('entity_id', DB::raw('COUNT(*) as count'))
+            ->groupBy('entity_id')
+            ->orderByDesc('count')
+            ->limit($limit)
+            ->get();
+    }
+
+    /** @return Collection<int, object> */
+    public function changesPerDay(string $entityClass, int $days = 30): Collection
+    {
+        return EloquentAuditLog::forEntity($entityClass)
+            ->newQuery()
+            ->selectRaw('DATE(created_at) as date, action, COUNT(*) as count')
+            ->where('created_at', '>=', now()->subDays($days))
+            ->groupBy('date', 'action')
+            ->orderBy('date')
+            ->get();
+    }
+}

--- a/src/Services/AuditFieldTransformer.php
+++ b/src/Services/AuditFieldTransformer.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+final class AuditFieldTransformer
+{
+    /**
+     * @param array<string, mixed> $attributes
+     * @return array<string, mixed>
+     */
+    public function transform(array $attributes, Model $model, string $direction): array
+    {
+        $redactedFields = config('audit-logger.fields.redact', []);
+        $replacement = config('audit-logger.fields.redaction_replacement', '[REDACTED]');
+        $transformers = config('audit-logger.fields.transformers', []);
+
+        foreach ($attributes as $field => $value) {
+            if (in_array($field, $redactedFields, true)) {
+                $attributes[$field] = $replacement;
+                continue;
+            }
+
+            if (array_key_exists($field, $transformers)) {
+                $attributes[$field] = $this->resolve($transformers[$field])->transform($field, $value, $direction, $model);
+            }
+        }
+
+        return $attributes;
+    }
+
+    private function resolve(mixed $transformer): FieldTransformerInterface
+    {
+        if ($transformer instanceof FieldTransformerInterface) {
+            return $transformer;
+        }
+
+        if (is_string($transformer) && class_exists($transformer)) {
+            $instance = app($transformer);
+            if ($instance instanceof FieldTransformerInterface) {
+                return $instance;
+            }
+        }
+
+        throw new InvalidArgumentException('Audit field transformers must implement '.FieldTransformerInterface::class.'.');
+    }
+}

--- a/src/Services/AuditFieldTransformer.php
+++ b/src/Services/AuditFieldTransformer.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
 final class AuditFieldTransformer
 {
     /**
-     * @param array<string, mixed> $attributes
+     * @param  array<string, mixed>  $attributes
      * @return array<string, mixed>
      */
     public function transform(array $attributes, Model $model, string $direction): array
@@ -23,6 +23,7 @@ final class AuditFieldTransformer
         foreach ($attributes as $field => $value) {
             if (in_array($field, $redactedFields, true)) {
                 $attributes[$field] = $replacement;
+
                 continue;
             }
 

--- a/src/Services/AuditHash.php
+++ b/src/Services/AuditHash.php
@@ -15,7 +15,7 @@ final class AuditHash
 
     public function compute(AuditLogInterface $log, ?string $previousHash): string
     {
-        $payload = [
+        $payload = $this->sortRecursive([
             'previous_hash' => $previousHash,
             'entity_type' => $log->getEntityType(),
             'entity_id' => (string) $log->getEntityId(),
@@ -27,12 +27,42 @@ final class AuditHash
             'metadata' => $log->getMetadata(),
             'source' => $log->getSource(),
             'created_at' => $log->getCreatedAt()->format(DATE_ATOM),
-        ];
+        ]);
 
         $serialized = json_encode($payload, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
         $algorithm = (string) config('audit-logger.security.hashing.algorithm', 'sha256');
+
+        return hash_hmac($algorithm, $serialized, $this->key());
+    }
+
+    /** @param array<mixed> $value */
+    private function sortRecursive(array $value): array
+    {
+        foreach ($value as $key => $item) {
+            if (is_array($item)) {
+                $value[$key] = $this->sortRecursive($item);
+            }
+        }
+
+        if (! array_is_list($value)) {
+            ksort($value);
+        }
+
+        return $value;
+    }
+
+    private function key(): string
+    {
         $key = (string) config('audit-logger.security.hashing.key', config('app.key', ''));
 
-        return hash_hmac($algorithm, $serialized, $key);
+        if (str_starts_with($key, 'base64:')) {
+            $decoded = base64_decode(substr($key, 7), true);
+
+            if ($decoded !== false) {
+                return $decoded;
+            }
+        }
+
+        return $key;
     }
 }

--- a/src/Services/AuditHash.php
+++ b/src/Services/AuditHash.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+
+final class AuditHash
+{
+    public function enabled(): bool
+    {
+        return (bool) config('audit-logger.security.hashing.enabled', false);
+    }
+
+    public function compute(AuditLogInterface $log, ?string $previousHash): string
+    {
+        $payload = [
+            'previous_hash' => $previousHash,
+            'entity_type' => $log->getEntityType(),
+            'entity_id' => (string) $log->getEntityId(),
+            'action' => $log->getAction(),
+            'old_values' => $log->getOldValues(),
+            'new_values' => $log->getNewValues(),
+            'causer_type' => $log->getCauserType(),
+            'causer_id' => $log->getCauserId() === null ? null : (string) $log->getCauserId(),
+            'metadata' => $log->getMetadata(),
+            'source' => $log->getSource(),
+            'created_at' => $log->getCreatedAt()->format(DATE_ATOM),
+        ];
+
+        $serialized = json_encode($payload, JSON_PRESERVE_ZERO_FRACTION | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        $algorithm = (string) config('audit-logger.security.hashing.algorithm', 'sha256');
+        $key = (string) config('audit-logger.security.hashing.key', config('app.key', ''));
+
+        return hash_hmac($algorithm, $serialized, $key);
+    }
+}

--- a/src/Services/AuditHashVerifier.php
+++ b/src/Services/AuditHashVerifier.php
@@ -31,6 +31,10 @@ final class AuditHashVerifier
             );
         }
 
+        $previousHash = null;
+        $failures = [];
+        $checked = 0;
+
         try {
             $query = $model->newQuery()->orderBy('id');
 
@@ -38,44 +42,40 @@ final class AuditHashVerifier
                 $query->where('entity_id', (string) $entityId);
             }
 
-            $logs = $query->get();
+            foreach ($query->lazy() as $log) {
+                $checked++;
+                $expected = $this->hash->compute(AuditLog::fromArray([
+                    'entity_type' => $entityClass,
+                    'entity_id' => $log->entity_id,
+                    'action' => $log->action,
+                    'old_values' => $log->old_values,
+                    'new_values' => $log->new_values,
+                    'causer_type' => $log->causer_type,
+                    'causer_id' => $log->causer_id,
+                    'metadata' => $log->metadata ?? [],
+                    'created_at' => $log->created_at,
+                    'source' => $log->source,
+                ]), $previousHash);
+
+                if (($log->previous_hash ?? null) !== $previousHash || ($log->audit_hash ?? null) !== $expected) {
+                    $failures[] = [
+                        'code' => 'hash_mismatch',
+                        'message' => 'The stored audit hash or previous hash does not match the expected value.',
+                        'id' => $log->getKey(),
+                        'expected_previous_hash' => $previousHash,
+                        'actual_previous_hash' => $log->previous_hash ?? null,
+                        'expected_audit_hash' => $expected,
+                        'actual_audit_hash' => $log->audit_hash ?? null,
+                    ];
+                }
+
+                $previousHash = $log->audit_hash ?? null;
+            }
         } catch (Throwable $exception) {
             return $this->failure('verification_query_failed', $exception->getMessage());
         }
 
-        $previousHash = null;
-        $failures = [];
-
-        foreach ($logs as $log) {
-            $expected = $this->hash->compute(AuditLog::fromArray([
-                'entity_type' => $entityClass,
-                'entity_id' => $log->entity_id,
-                'action' => $log->action,
-                'old_values' => $log->old_values,
-                'new_values' => $log->new_values,
-                'causer_type' => $log->causer_type,
-                'causer_id' => $log->causer_id,
-                'metadata' => $log->metadata ?? [],
-                'created_at' => $log->created_at,
-                'source' => $log->source,
-            ]), $previousHash);
-
-            if (($log->previous_hash ?? null) !== $previousHash || ($log->audit_hash ?? null) !== $expected) {
-                $failures[] = [
-                    'code' => 'hash_mismatch',
-                    'message' => 'The stored audit hash or previous hash does not match the expected value.',
-                    'id' => $log->getKey(),
-                    'expected_previous_hash' => $previousHash,
-                    'actual_previous_hash' => $log->previous_hash ?? null,
-                    'expected_audit_hash' => $expected,
-                    'actual_audit_hash' => $log->audit_hash ?? null,
-                ];
-            }
-
-            $previousHash = $log->audit_hash ?? null;
-        }
-
-        return ['valid' => $failures === [], 'checked' => $logs->count(), 'failures' => $failures];
+        return ['valid' => $failures === [], 'checked' => $checked, 'failures' => $failures];
     }
 
     /** @return array{valid: false, checked: 0, failures: array<int, array<string, string>>} */

--- a/src/Services/AuditHashVerifier.php
+++ b/src/Services/AuditHashVerifier.php
@@ -6,6 +6,8 @@ namespace iamfarhad\LaravelAuditLog\Services;
 
 use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Support\Facades\Schema;
+use Throwable;
 
 final class AuditHashVerifier
 {
@@ -14,13 +16,33 @@ final class AuditHashVerifier
     /** @return array{valid: bool, checked: int, failures: array<int, array<string, mixed>>} */
     public function verify(string $entityClass, string|int|null $entityId = null): array
     {
-        $query = EloquentAuditLog::forEntity($entityClass)->newQuery()->orderBy('id');
+        $model = EloquentAuditLog::forEntity($entityClass);
+        $connection = $model->getConnectionName();
+        $table = $model->getTable();
 
-        if ($entityId !== null) {
-            $query->where('entity_id', (string) $entityId);
+        if (! Schema::connection($connection)->hasTable($table)) {
+            return $this->failure('missing_audit_table', "Audit table [{$table}] does not exist.");
         }
 
-        $logs = $query->get();
+        if (! Schema::connection($connection)->hasColumn($table, 'audit_hash') || ! Schema::connection($connection)->hasColumn($table, 'previous_hash')) {
+            return $this->failure(
+                'missing_hash_columns',
+                "Audit table [{$table}] must have nullable [audit_hash] and [previous_hash] columns before hash-chain verification can run."
+            );
+        }
+
+        try {
+            $query = $model->newQuery()->orderBy('id');
+
+            if ($entityId !== null) {
+                $query->where('entity_id', (string) $entityId);
+            }
+
+            $logs = $query->get();
+        } catch (Throwable $exception) {
+            return $this->failure('verification_query_failed', $exception->getMessage());
+        }
+
         $previousHash = null;
         $failures = [];
 
@@ -40,6 +62,8 @@ final class AuditHashVerifier
 
             if (($log->previous_hash ?? null) !== $previousHash || ($log->audit_hash ?? null) !== $expected) {
                 $failures[] = [
+                    'code' => 'hash_mismatch',
+                    'message' => 'The stored audit hash or previous hash does not match the expected value.',
                     'id' => $log->getKey(),
                     'expected_previous_hash' => $previousHash,
                     'actual_previous_hash' => $log->previous_hash ?? null,
@@ -52,5 +76,17 @@ final class AuditHashVerifier
         }
 
         return ['valid' => $failures === [], 'checked' => $logs->count(), 'failures' => $failures];
+    }
+
+    /** @return array{valid: false, checked: 0, failures: array<int, array<string, string>>} */
+    private function failure(string $code, string $message): array
+    {
+        return [
+            'valid' => false,
+            'checked' => 0,
+            'failures' => [
+                ['code' => $code, 'message' => $message],
+            ],
+        ];
     }
 }

--- a/src/Services/AuditHashVerifier.php
+++ b/src/Services/AuditHashVerifier.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+
+final class AuditHashVerifier
+{
+    public function __construct(private readonly AuditHash $hash) {}
+
+    /** @return array{valid: bool, checked: int, failures: array<int, array<string, mixed>>} */
+    public function verify(string $entityClass, string|int|null $entityId = null): array
+    {
+        $query = EloquentAuditLog::forEntity($entityClass)->newQuery()->orderBy('id');
+
+        if ($entityId !== null) {
+            $query->where('entity_id', (string) $entityId);
+        }
+
+        $logs = $query->get();
+        $previousHash = null;
+        $failures = [];
+
+        foreach ($logs as $log) {
+            $expected = $this->hash->compute(AuditLog::fromArray([
+                'entity_type' => $entityClass,
+                'entity_id' => $log->entity_id,
+                'action' => $log->action,
+                'old_values' => $log->old_values,
+                'new_values' => $log->new_values,
+                'causer_type' => $log->causer_type,
+                'causer_id' => $log->causer_id,
+                'metadata' => $log->metadata ?? [],
+                'created_at' => $log->created_at,
+                'source' => $log->source,
+            ]), $previousHash);
+
+            if (($log->previous_hash ?? null) !== $previousHash || ($log->audit_hash ?? null) !== $expected) {
+                $failures[] = [
+                    'id' => $log->getKey(),
+                    'expected_previous_hash' => $previousHash,
+                    'actual_previous_hash' => $log->previous_hash ?? null,
+                    'expected_audit_hash' => $expected,
+                    'actual_audit_hash' => $log->audit_hash ?? null,
+                ];
+            }
+
+            $previousHash = $log->audit_hash ?? null;
+        }
+
+        return ['valid' => $failures === [], 'checked' => $logs->count(), 'failures' => $failures];
+    }
+}

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -7,6 +7,7 @@ namespace iamfarhad\LaravelAuditLog\Services;
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
 use iamfarhad\LaravelAuditLog\Drivers\MySQLDriver;
+use iamfarhad\LaravelAuditLog\Drivers\PostgreSQLDriver;
 use iamfarhad\LaravelAuditLog\Jobs\ProcessAuditLogJob;
 use iamfarhad\LaravelAuditLog\Jobs\ProcessAuditLogSyncJob;
 use Illuminate\Support\Facades\App;
@@ -29,23 +30,17 @@ final class AuditLogger
         }
     }
 
-    /**
-     * @param  array<AuditLogInterface>  $logs
-     *
-     * @throws \Exception
-     */
+    /** @param array<AuditLogInterface> $logs */
     public function batch(array $logs): void
     {
         if (! (bool) config('audit-logger.enabled', true)) {
             return;
         }
 
-        if ((bool) config('audit-logger.queue.enabled', false)) {
-            foreach ($logs as $log) {
+        foreach ($logs as $log) {
+            if ((bool) config('audit-logger.queue.enabled', false)) {
                 ProcessAuditLogJob::dispatch($log, $this->driver);
-            }
-        } else {
-            foreach ($logs as $log) {
+            } else {
                 ProcessAuditLogSyncJob::dispatchSync($log, $this->driver);
             }
         }
@@ -53,19 +48,52 @@ final class AuditLogger
 
     public static function getDriver(string $driverName, ?string $connection = null): static
     {
-        $connection = $connection ?? config('audit-logger.drivers.mysql.connection') ?? config('database.default');
+        $connection = $connection
+            ?? config("audit-logger.drivers.{$driverName}.connection")
+            ?? config('database.default');
 
         $driver = match ($driverName) {
             'mysql' => new MySQLDriver($connection),
+            'postgresql', 'pgsql' => new PostgreSQLDriver($connection),
             default => throw new \InvalidArgumentException("Driver {$driverName} not found"),
         };
 
         return new self($driver);
     }
 
+    public function query(string $entityClass): AuditQuery
+    {
+        return new AuditQuery($entityClass);
+    }
+
+    public function search(string $entityClass, string $term): AuditQuery
+    {
+        return $this->query($entityClass)->search($term);
+    }
+
+    public function analytics(): AuditAnalytics
+    {
+        return app(AuditAnalytics::class);
+    }
+
+    public function timeline(): AuditTimeline
+    {
+        return app(AuditTimeline::class);
+    }
+
+    public function restorer(): AuditRestorer
+    {
+        return app(AuditRestorer::class);
+    }
+
+    /** @return array{valid: bool, checked: int, failures: array<int, array<string, mixed>>} */
+    public function verifyHashChain(string $entityClass, string|int|null $entityId = null): array
+    {
+        return app(AuditHashVerifier::class)->verify($entityClass, $entityId);
+    }
+
     public function getSource(): ?string
     {
-
         if (App::runningInConsole()) {
             $command = request()->server('argv')[1] ?? null;
 

--- a/src/Services/AuditQuery.php
+++ b/src/Services/AuditQuery.php
@@ -8,7 +8,6 @@ use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
 
 final class AuditQuery
 {
@@ -54,9 +53,11 @@ final class AuditQuery
     {
         $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
         $jsonColumns = ['old_values', 'new_values', 'metadata'];
-        $isPostgreSQL = $this->query->getModel()->getConnection()->getDriverName() === 'pgsql';
+        $connection = $this->query->getModel()->getConnection();
+        $grammar = $connection->getQueryGrammar();
+        $isPostgreSQL = $connection->getDriverName() === 'pgsql';
 
-        $this->query->where(function (Builder $query) use ($isPostgreSQL, $jsonColumns, $like): void {
+        $this->query->where(function (Builder $query) use ($grammar, $isPostgreSQL, $jsonColumns, $like): void {
             $query->where('entity_id', 'like', $like)
                 ->orWhere('action', 'like', $like)
                 ->orWhere('source', 'like', $like)
@@ -65,7 +66,7 @@ final class AuditQuery
 
             foreach ($jsonColumns as $column) {
                 if ($isPostgreSQL) {
-                    $query->orWhereRaw(DB::getQueryGrammar()->wrap($column).'::text LIKE ?', [$like]);
+                    $query->orWhereRaw($grammar->wrap($column).'::text LIKE ?', [$like]);
                 } else {
                     $query->orWhere($column, 'like', $like);
                 }

--- a/src/Services/AuditQuery.php
+++ b/src/Services/AuditQuery.php
@@ -21,12 +21,14 @@ final class AuditQuery
     public function forEntityId(string|int $entityId): self
     {
         $this->query->where('entity_id', (string) $entityId);
+
         return $this;
     }
 
     public function forAction(string|array $action): self
     {
         is_array($action) ? $this->query->whereIn('action', $action) : $this->query->where('action', $action);
+
         return $this;
     }
 
@@ -36,12 +38,14 @@ final class AuditQuery
         if ($causerId !== null) {
             $this->query->where('causer_id', (string) $causerId);
         }
+
         return $this;
     }
 
     public function between(mixed $from, mixed $to): self
     {
         $this->query->whereBetween('created_at', [$from, $to]);
+
         return $this;
     }
 
@@ -58,12 +62,14 @@ final class AuditQuery
                 ->orWhere('new_values', 'like', $like)
                 ->orWhere('metadata', 'like', $like);
         });
+
         return $this;
     }
 
     public function latest(): self
     {
         $this->query->orderByDesc('created_at')->orderByDesc('id');
+
         return $this;
     }
 
@@ -77,6 +83,7 @@ final class AuditQuery
     {
         /** @var EloquentAuditLog|null $log */
         $log = $this->query->first($columns);
+
         return $log;
     }
 

--- a/src/Services/AuditQuery.php
+++ b/src/Services/AuditQuery.php
@@ -8,6 +8,7 @@ use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
 use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
 
 final class AuditQuery
 {
@@ -52,15 +53,23 @@ final class AuditQuery
     public function search(string $term): self
     {
         $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
-        $this->query->where(function (Builder $query) use ($like): void {
+        $jsonColumns = ['old_values', 'new_values', 'metadata'];
+        $isPostgreSQL = $this->query->getModel()->getConnection()->getDriverName() === 'pgsql';
+
+        $this->query->where(function (Builder $query) use ($isPostgreSQL, $jsonColumns, $like): void {
             $query->where('entity_id', 'like', $like)
                 ->orWhere('action', 'like', $like)
                 ->orWhere('source', 'like', $like)
                 ->orWhere('causer_type', 'like', $like)
-                ->orWhere('causer_id', 'like', $like)
-                ->orWhere('old_values', 'like', $like)
-                ->orWhere('new_values', 'like', $like)
-                ->orWhere('metadata', 'like', $like);
+                ->orWhere('causer_id', 'like', $like);
+
+            foreach ($jsonColumns as $column) {
+                if ($isPostgreSQL) {
+                    $query->orWhereRaw(DB::getQueryGrammar()->wrap($column).'::text LIKE ?', [$like]);
+                } else {
+                    $query->orWhere($column, 'like', $like);
+                }
+            }
         });
 
         return $this;

--- a/src/Services/AuditQuery.php
+++ b/src/Services/AuditQuery.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+final class AuditQuery
+{
+    private Builder $query;
+
+    public function __construct(private readonly string $entityClass)
+    {
+        $this->query = EloquentAuditLog::forEntity($entityClass)->newQuery();
+    }
+
+    public function forEntityId(string|int $entityId): self
+    {
+        $this->query->where('entity_id', (string) $entityId);
+        return $this;
+    }
+
+    public function forAction(string|array $action): self
+    {
+        is_array($action) ? $this->query->whereIn('action', $action) : $this->query->where('action', $action);
+        return $this;
+    }
+
+    public function forCauser(string $causerType, string|int|null $causerId = null): self
+    {
+        $this->query->where('causer_type', $causerType);
+        if ($causerId !== null) {
+            $this->query->where('causer_id', (string) $causerId);
+        }
+        return $this;
+    }
+
+    public function between(mixed $from, mixed $to): self
+    {
+        $this->query->whereBetween('created_at', [$from, $to]);
+        return $this;
+    }
+
+    public function search(string $term): self
+    {
+        $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $term).'%';
+        $this->query->where(function (Builder $query) use ($like): void {
+            $query->where('entity_id', 'like', $like)
+                ->orWhere('action', 'like', $like)
+                ->orWhere('source', 'like', $like)
+                ->orWhere('causer_type', 'like', $like)
+                ->orWhere('causer_id', 'like', $like)
+                ->orWhere('old_values', 'like', $like)
+                ->orWhere('new_values', 'like', $like)
+                ->orWhere('metadata', 'like', $like);
+        });
+        return $this;
+    }
+
+    public function latest(): self
+    {
+        $this->query->orderByDesc('created_at')->orderByDesc('id');
+        return $this;
+    }
+
+    /** @return Collection<int, EloquentAuditLog> */
+    public function get(array $columns = ['*']): Collection
+    {
+        return $this->query->get($columns);
+    }
+
+    public function first(array $columns = ['*']): ?EloquentAuditLog
+    {
+        /** @var EloquentAuditLog|null $log */
+        $log = $this->query->first($columns);
+        return $log;
+    }
+
+    public function paginate(int $perPage = 15, array $columns = ['*']): LengthAwarePaginator
+    {
+        return $this->query->paginate($perPage, $columns);
+    }
+}

--- a/src/Services/AuditRestorer.php
+++ b/src/Services/AuditRestorer.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
+
+final class AuditRestorer
+{
+    public function restore(Model $model, EloquentAuditLog|int|string $auditLog, bool $save = true): Model
+    {
+        return $this->apply($model, $auditLog, 'new', $save);
+    }
+
+    public function rollback(Model $model, EloquentAuditLog|int|string $auditLog, bool $save = true): Model
+    {
+        return $this->apply($model, $auditLog, 'old', $save);
+    }
+
+    /** @return array<int, array{field: string, current: mixed, target: mixed}> */
+    public function preview(Model $model, EloquentAuditLog|int|string $auditLog, string $mode = 'new'): array
+    {
+        $log = $this->resolveLog($model, $auditLog);
+        $values = $this->valuesForMode($log, $mode);
+        $changes = [];
+
+        foreach ($values as $field => $targetValue) {
+            $currentValue = $model->getAttribute((string) $field);
+            if ($currentValue !== $targetValue) {
+                $changes[] = ['field' => (string) $field, 'current' => $currentValue, 'target' => $targetValue];
+            }
+        }
+
+        return $changes;
+    }
+
+    private function apply(Model $model, EloquentAuditLog|int|string $auditLog, string $mode, bool $save): Model
+    {
+        $log = $this->resolveLog($model, $auditLog);
+        $values = $this->valuesForMode($log, $mode);
+
+        if ($values === []) {
+            throw new InvalidArgumentException("The selected audit log does not contain {$mode} values to apply.");
+        }
+
+        $model->forceFill($values);
+
+        if ($save) {
+            $model->save();
+        }
+
+        return $model;
+    }
+
+    private function resolveLog(Model $model, EloquentAuditLog|int|string $auditLog): EloquentAuditLog
+    {
+        if ($auditLog instanceof EloquentAuditLog) {
+            return $auditLog;
+        }
+
+        /** @var EloquentAuditLog|null $log */
+        $log = EloquentAuditLog::forEntity($model::class)
+            ->newQuery()
+            ->where('entity_id', (string) $model->getKey())
+            ->whereKey($auditLog)
+            ->first();
+
+        if (! $log instanceof EloquentAuditLog) {
+            throw new InvalidArgumentException('Audit log not found for this model.');
+        }
+
+        return $log;
+    }
+
+    /** @return array<string, mixed> */
+    private function valuesForMode(EloquentAuditLog $log, string $mode): array
+    {
+        $values = match ($mode) {
+            'new', 'restore', 'replay' => $log->new_values,
+            'old', 'rollback' => $log->old_values,
+            default => throw new InvalidArgumentException('Restore mode must be new, old, restore, replay, or rollback.'),
+        };
+
+        return is_array($values) ? $values : [];
+    }
+}

--- a/src/Services/AuditRestorer.php
+++ b/src/Services/AuditRestorer.php
@@ -58,6 +58,8 @@ final class AuditRestorer
     private function resolveLog(Model $model, EloquentAuditLog|int|string $auditLog): EloquentAuditLog
     {
         if ($auditLog instanceof EloquentAuditLog) {
+            $this->ensureLogBelongsToModel($model, $auditLog);
+
             return $auditLog;
         }
 
@@ -73,6 +75,15 @@ final class AuditRestorer
         }
 
         return $log;
+    }
+
+    private function ensureLogBelongsToModel(Model $model, EloquentAuditLog $log): void
+    {
+        $expectedTable = EloquentAuditLog::forEntity($model::class)->getTable();
+
+        if ($log->getTable() !== $expectedTable || (string) $log->entity_id !== (string) $model->getKey()) {
+            throw new InvalidArgumentException('Audit log not found for this model.');
+        }
     }
 
     /** @return array<string, mixed> */

--- a/src/Services/AuditTimeline.php
+++ b/src/Services/AuditTimeline.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
+
+final class AuditTimeline
+{
+    /** @return Collection<int, array<string, mixed>> */
+    public function forModel(Model $model): Collection
+    {
+        return EloquentAuditLog::forEntity($model::class)
+            ->newQuery()
+            ->where('entity_id', (string) $model->getKey())
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get()
+            ->map(fn (EloquentAuditLog $log): array => $this->entry($log));
+    }
+
+    /** @return array<string, mixed> */
+    public function entry(EloquentAuditLog $log): array
+    {
+        return [
+            'id' => $log->getKey(),
+            'action' => $log->action,
+            'entity_id' => $log->entity_id,
+            'causer_type' => $log->causer_type,
+            'causer_id' => $log->causer_id,
+            'source' => $log->source,
+            'created_at' => $log->created_at,
+            'changes' => $this->diff($log),
+            'metadata' => $log->metadata ?? [],
+            'audit_hash' => $log->audit_hash ?? null,
+            'previous_hash' => $log->previous_hash ?? null,
+        ];
+    }
+
+    /** @return array<int, array{field: string, old: mixed, new: mixed}> */
+    public function diff(EloquentAuditLog $log): array
+    {
+        $oldValues = is_array($log->old_values) ? $log->old_values : [];
+        $newValues = is_array($log->new_values) ? $log->new_values : [];
+        $fields = array_unique(array_merge(array_keys($oldValues), array_keys($newValues)));
+        $diff = [];
+
+        foreach ($fields as $field) {
+            $old = $oldValues[$field] ?? null;
+            $new = $newValues[$field] ?? null;
+            if ($old !== $new) {
+                $diff[] = ['field' => (string) $field, 'old' => $old, 'new' => $new];
+            }
+        }
+
+        return $diff;
+    }
+}

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -162,11 +162,6 @@ trait Auditable
         return app(AuditFieldTransformer::class)->transform($auditable, $this, $direction);
     }
 
-    public function getKey(): string|int
-    {
-        return $this->getAttribute($this->getKeyName());
-    }
-
     public function auditLogs()
     {
         return EloquentAuditLog::forEntity(static::class)

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -117,18 +117,21 @@ trait Auditable
         if (! (bool) config('audit-logger.enabled', true)) {
             return false;
         }
+
         return ! property_exists($this, 'auditingEnabled') || $this->auditingEnabled;
     }
 
     public function enableAuditing(): self
     {
         $this->auditingEnabled = true;
+
         return $this;
     }
 
     public function disableAuditing(): self
     {
         $this->auditingEnabled = false;
+
         return $this;
     }
 
@@ -199,12 +202,14 @@ trait Auditable
     public function restoreFromAudit(EloquentAuditLog|int|string $auditLog, bool $save = true): self
     {
         app(AuditRestorer::class)->restore($this, $auditLog, $save);
+
         return $this;
     }
 
     public function rollbackToAudit(EloquentAuditLog|int|string $auditLog, bool $save = true): self
     {
         app(AuditRestorer::class)->rollback($this, $auditLog, $save);
+
         return $this;
     }
 
@@ -227,24 +232,28 @@ trait Auditable
     public function isRetentionEnabled(): bool
     {
         $config = $this->getAuditRetentionConfig();
+
         return isset($config['enabled']) ? (bool) $config['enabled'] : config('audit-logger.retention.enabled', false);
     }
 
     public function getRetentionStrategy(): string
     {
         $config = $this->getAuditRetentionConfig();
+
         return $config['strategy'] ?? config('audit-logger.retention.strategy', 'delete');
     }
 
     public function getRetentionDays(): int
     {
         $config = $this->getAuditRetentionConfig();
+
         return $config['days'] ?? config('audit-logger.retention.days', 365);
     }
 
     public function getAnonymizeDays(): int
     {
         $config = $this->getAuditRetentionConfig();
+
         return $config['anonymize_after_days'] ?? config('audit-logger.retention.anonymize_after_days', 180);
     }
 }

--- a/src/Traits/Auditable.php
+++ b/src/Traits/Auditable.php
@@ -9,195 +9,156 @@ use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
 use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
 use iamfarhad\LaravelAuditLog\Services\AuditBuilder;
+use iamfarhad\LaravelAuditLog\Services\AuditFieldTransformer;
 use iamfarhad\LaravelAuditLog\Services\AuditLogger;
+use iamfarhad\LaravelAuditLog\Services\AuditQuery;
+use iamfarhad\LaravelAuditLog\Services\AuditRestorer;
+use iamfarhad\LaravelAuditLog\Services\AuditTimeline;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Collection;
 
-/**
- * Trait that implements the AuditableInterface to make models auditable.
- */
 trait Auditable
 {
-    /**
-     * Boot the auditable trait.
-     */
     public static function bootAuditable(): void
     {
         static::created(function (Model $model) {
-            if ($model->isAuditingEnabled()) {
-                $auditLogger = app(AuditLogger::class);
-                $causerResolver = app(CauserResolverInterface::class);
-                $causer = $causerResolver->resolve();
-
-                $auditLogger->log(new AuditLog(
-                    entityType: $model->getAuditEntityType(),
-                    entityId: $model->getKey(),
-                    action: 'created',
-                    oldValues: null,
-                    newValues: $model->getAuditableAttributes($model->getAttributes()),
-                    metadata: $model->getAuditMetadata(),
-                    causerType: $causer['type'],
-                    causerId: $causer['id'],
-                    createdAt: Carbon::now(),
-                    source: $auditLogger->getSource(),
-                ));
+            if (! $model->isAuditingEnabled()) {
+                return;
             }
+            $auditLogger = app(AuditLogger::class);
+            $causer = app(CauserResolverInterface::class)->resolve();
+            $auditLogger->log(new AuditLog(
+                entityType: $model->getAuditEntityType(),
+                entityId: $model->getKey(),
+                action: 'created',
+                oldValues: null,
+                newValues: $model->getAuditableAttributes($model->getAttributes(), 'new'),
+                metadata: $model->getAuditMetadata(),
+                causerType: $causer['type'],
+                causerId: $causer['id'],
+                createdAt: Carbon::now(),
+                source: $auditLogger->getSource(),
+            ));
         });
 
         static::updated(function (Model $model) {
-            if ($model->isAuditingEnabled()) {
-                $oldValues = $model->getAuditableAttributes($model->getOriginal());
-                $newValues = $model->getAuditableAttributes($model->getChanges());
-
-                $oldValues = array_intersect_key($oldValues, $newValues);
-
-                if (! empty($newValues)) {
-                    $auditLogger = app(AuditLogger::class);
-                    $causerResolver = app(CauserResolverInterface::class);
-                    $causer = $causerResolver->resolve();
-
-                    $auditLogger->log(new AuditLog(
-                        entityType: $model->getAuditEntityType(),
-                        entityId: $model->getKey(),
-                        action: 'updated',
-                        oldValues: $oldValues,
-                        newValues: $newValues,
-                        metadata: $model->getAuditMetadata(),
-                        causerType: $causer['type'],
-                        causerId: $causer['id'],
-                        createdAt: Carbon::now(),
-                        source: $auditLogger->getSource(),
-                    ));
-                }
+            if (! $model->isAuditingEnabled()) {
+                return;
             }
+            $oldValues = $model->getAuditableAttributes($model->getOriginal(), 'old');
+            $newValues = $model->getAuditableAttributes($model->getChanges(), 'new');
+            $oldValues = array_intersect_key($oldValues, $newValues);
+
+            if ($newValues === []) {
+                return;
+            }
+
+            $auditLogger = app(AuditLogger::class);
+            $causer = app(CauserResolverInterface::class)->resolve();
+            $auditLogger->log(new AuditLog(
+                entityType: $model->getAuditEntityType(),
+                entityId: $model->getKey(),
+                action: 'updated',
+                oldValues: $oldValues,
+                newValues: $newValues,
+                metadata: $model->getAuditMetadata(),
+                causerType: $causer['type'],
+                causerId: $causer['id'],
+                createdAt: Carbon::now(),
+                source: $auditLogger->getSource(),
+            ));
         });
 
         static::deleted(function (Model $model) {
-            if ($model->isAuditingEnabled()) {
-                $auditLogger = app(AuditLogger::class);
-                $causerResolver = app(CauserResolverInterface::class);
-                $causer = $causerResolver->resolve();
-
-                $auditLogger->log(new AuditLog(
-                    entityType: $model->getAuditEntityType(),
-                    entityId: $model->getKey(),
-                    action: 'deleted',
-                    oldValues: $model->getAuditableAttributes($model->getOriginal()),
-                    newValues: null,
-                    metadata: $model->getAuditMetadata(),
-                    causerType: $causer['type'],
-                    causerId: $causer['id'],
-                    createdAt: Carbon::now(),
-                    source: $auditLogger->getSource(),
-                ));
+            if (! $model->isAuditingEnabled()) {
+                return;
             }
+            $auditLogger = app(AuditLogger::class);
+            $causer = app(CauserResolverInterface::class)->resolve();
+            $auditLogger->log(new AuditLog(
+                entityType: $model->getAuditEntityType(),
+                entityId: $model->getKey(),
+                action: 'deleted',
+                oldValues: $model->getAuditableAttributes($model->getOriginal(), 'old'),
+                newValues: null,
+                metadata: $model->getAuditMetadata(),
+                causerType: $causer['type'],
+                causerId: $causer['id'],
+                createdAt: Carbon::now(),
+                source: $auditLogger->getSource(),
+            ));
         });
 
         if (method_exists(static::class, 'restored')) {
             static::restored(function (Model $model) {
-                if ($model->isAuditingEnabled()) {
-                    $auditLogger = app(AuditLogger::class);
-                    $causerResolver = app(CauserResolverInterface::class);
-                    $causer = $causerResolver->resolve();
-
-                    $auditLogger->log(new AuditLog(
-                        entityType: $model->getAuditEntityType(),
-                        entityId: $model->getKey(),
-                        action: 'restored',
-                        oldValues: null,
-                        newValues: $model->getAuditableAttributes($model->getAttributes()),
-                        metadata: $model->getAuditMetadata(),
-                        causerType: $causer['type'],
-                        causerId: $causer['id'],
-                        createdAt: Carbon::now(),
-                        source: $auditLogger->getSource(),
-                    ));
+                if (! $model->isAuditingEnabled()) {
+                    return;
                 }
+                $auditLogger = app(AuditLogger::class);
+                $causer = app(CauserResolverInterface::class)->resolve();
+                $auditLogger->log(new AuditLog(
+                    entityType: $model->getAuditEntityType(),
+                    entityId: $model->getKey(),
+                    action: 'restored',
+                    oldValues: null,
+                    newValues: $model->getAuditableAttributes($model->getAttributes(), 'new'),
+                    metadata: $model->getAuditMetadata(),
+                    causerType: $causer['type'],
+                    causerId: $causer['id'],
+                    createdAt: Carbon::now(),
+                    source: $auditLogger->getSource(),
+                ));
             });
         }
     }
 
-    /**
-     * Determine if auditing is enabled for this model.
-     */
     public function isAuditingEnabled(): bool
     {
         if (! (bool) config('audit-logger.enabled', true)) {
             return false;
         }
-
-        if (! property_exists($this, 'auditingEnabled')) {
-            return true;
-        }
-
-        return $this->auditingEnabled;
+        return ! property_exists($this, 'auditingEnabled') || $this->auditingEnabled;
     }
 
-    /**
-     * Enable auditing for this model instance.
-     */
     public function enableAuditing(): self
     {
         $this->auditingEnabled = true;
-
         return $this;
     }
 
-    /**
-     * Disable auditing for this model instance.
-     */
     public function disableAuditing(): self
     {
         $this->auditingEnabled = false;
-
         return $this;
     }
 
-    /**
-     * Get the entity type for audit logging.
-     */
     public function getAuditEntityType(): string
     {
         return static::class;
     }
 
-    /**
-     * Get custom metadata for audit logs.
-     */
     public function getAuditMetadata(): array
     {
         return [];
     }
 
-    /**
-     * Get the auditable attributes.
-     */
-    public function getAuditableAttributes(array $attributes): array
+    public function getAuditableAttributes(array $attributes, string $direction = 'new'): array
     {
-        // Get exclude fields - combining model property and global config
         $exclude = config('audit-logger.fields.exclude', []);
-
+        if (! (bool) config('audit-logger.fields.include_timestamps', true)) {
+            $exclude = array_merge($exclude, ['created_at', 'updated_at', 'deleted_at']);
+        }
         if (property_exists($this, 'auditExclude')) {
             $exclude = array_merge($exclude, $this->auditExclude);
         }
-
         $include = property_exists($this, 'auditInclude') ? $this->auditInclude : ['*'];
+        $auditable = $include === ['*']
+            ? array_diff_key($attributes, array_flip($exclude))
+            : array_diff_key(array_intersect_key($attributes, array_flip($include)), array_flip($exclude));
 
-        // If include is ['*'], include all except excluded
-        if ($include === ['*']) {
-            return array_diff_key($attributes, array_flip($exclude));
-        }
-
-        // Otherwise, include only specified fields minus excluded
-        $included = array_intersect_key($attributes, array_flip($include));
-
-        return array_diff_key($included, array_flip($exclude));
+        return app(AuditFieldTransformer::class)->transform($auditable, $this, $direction);
     }
 
-    /**
-     * Get the primary key value for the model.
-     * This method is already provided by Eloquent Model, but we need to ensure
-     * it's available in the interface contract.
-     */
     public function getKey(): string|int
     {
         return $this->getAttribute($this->getKeyName());
@@ -205,73 +166,85 @@ trait Auditable
 
     public function auditLogs()
     {
-        return $this->morphMany(EloquentAuditLog::forEntity(static::class), 'auditable');
+        return EloquentAuditLog::forEntity(static::class)
+            ->newQuery()
+            ->where('entity_id', (string) $this->getKey());
     }
 
-    /**
-     * Initiate a fluent builder for custom audit logging.
-     */
+    public function auditHistory(): AuditQuery
+    {
+        return app(AuditLogger::class)->query(static::class)->forEntityId($this->getKey())->latest();
+    }
+
+    /** @return Collection<int, array<string, mixed>> */
+    public function auditTimeline(): Collection
+    {
+        return app(AuditTimeline::class)->forModel($this);
+    }
+
+    /** @return array<int, array{field: string, old: mixed, new: mixed}> */
+    public function auditDiff(EloquentAuditLog|int|string|null $auditLog = null): array
+    {
+        $log = $auditLog instanceof EloquentAuditLog
+            ? $auditLog
+            : $this->auditLogs()
+                ->when($auditLog !== null, fn ($query) => $query->whereKey($auditLog))
+                ->orderByDesc('created_at')
+                ->orderByDesc('id')
+                ->first();
+
+        return $log instanceof EloquentAuditLog ? app(AuditTimeline::class)->diff($log) : [];
+    }
+
+    public function restoreFromAudit(EloquentAuditLog|int|string $auditLog, bool $save = true): self
+    {
+        app(AuditRestorer::class)->restore($this, $auditLog, $save);
+        return $this;
+    }
+
+    public function rollbackToAudit(EloquentAuditLog|int|string $auditLog, bool $save = true): self
+    {
+        app(AuditRestorer::class)->rollback($this, $auditLog, $save);
+        return $this;
+    }
+
+    /** @return array<int, array{field: string, current: mixed, target: mixed}> */
+    public function previewRestore(EloquentAuditLog|int|string $auditLog, string $mode = 'restore'): array
+    {
+        return app(AuditRestorer::class)->preview($this, $auditLog, $mode);
+    }
+
     public function audit(): AuditBuilder
     {
         return new AuditBuilder($this);
     }
 
-    /**
-     * Get the retention configuration for this model.
-     * Models can override this to provide custom retention settings.
-     */
     public function getAuditRetentionConfig(): array
     {
-        if (property_exists($this, 'auditRetention') && is_array($this->auditRetention)) {
-            return $this->auditRetention;
-        }
-
-        return [];
+        return property_exists($this, 'auditRetention') && is_array($this->auditRetention) ? $this->auditRetention : [];
     }
 
-    /**
-     * Check if retention is enabled for this model.
-     */
     public function isRetentionEnabled(): bool
     {
         $config = $this->getAuditRetentionConfig();
-
-        // Check model-specific setting first
-        if (isset($config['enabled'])) {
-            return (bool) $config['enabled'];
-        }
-
-        // Fall back to global setting
-        return config('audit-logger.retention.enabled', false);
+        return isset($config['enabled']) ? (bool) $config['enabled'] : config('audit-logger.retention.enabled', false);
     }
 
-    /**
-     * Get the retention strategy for this model.
-     */
     public function getRetentionStrategy(): string
     {
         $config = $this->getAuditRetentionConfig();
-
         return $config['strategy'] ?? config('audit-logger.retention.strategy', 'delete');
     }
 
-    /**
-     * Get the retention days for this model.
-     */
     public function getRetentionDays(): int
     {
         $config = $this->getAuditRetentionConfig();
-
         return $config['days'] ?? config('audit-logger.retention.days', 365);
     }
 
-    /**
-     * Get the anonymization days for this model.
-     */
     public function getAnonymizeDays(): int
     {
         $config = $this->getAuditRetentionConfig();
-
         return $config['anonymize_after_days'] ?? config('audit-logger.retention.anonymize_after_days', 180);
     }
 }

--- a/src/Transformers/HashValueTransformer.php
+++ b/src/Transformers/HashValueTransformer.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Transformers;
+
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use Illuminate\Database\Eloquent\Model;
+
+final class HashValueTransformer implements FieldTransformerInterface
+{
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return hash('sha256', (string) $value);
+    }
+}

--- a/src/Transformers/MaskEmailTransformer.php
+++ b/src/Transformers/MaskEmailTransformer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Transformers;
+
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use Illuminate\Database\Eloquent\Model;
+
+final class MaskEmailTransformer implements FieldTransformerInterface
+{
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed
+    {
+        if (! is_string($value) || ! str_contains($value, '@')) {
+            return $value;
+        }
+
+        [$localPart, $domain] = explode('@', $value, 2);
+        $visible = mb_substr($localPart, 0, 1);
+
+        return $visible.str_repeat('*', max(3, mb_strlen($localPart) - 1)).'@'.$domain;
+    }
+}

--- a/src/Transformers/MaskValueTransformer.php
+++ b/src/Transformers/MaskValueTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Transformers;
+
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use Illuminate\Database\Eloquent\Model;
+
+final class MaskValueTransformer implements FieldTransformerInterface
+{
+    public function transform(string $field, mixed $value, string $direction, Model $model): mixed
+    {
+        if ($value === null || $value === '') {
+            return $value;
+        }
+
+        $stringValue = (string) $value;
+        $length = mb_strlen($stringValue);
+
+        if ($length <= 4) {
+            return str_repeat('*', $length);
+        }
+
+        return mb_substr($stringValue, 0, 2)
+            .str_repeat('*', max(0, $length - 4))
+            .mb_substr($stringValue, -2);
+    }
+}

--- a/tests/Feature/AdvancedAuditFeaturesTest.php
+++ b/tests/Feature/AdvancedAuditFeaturesTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Tests\Feature;
+
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger as AuditLoggerFacade;
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Tests\TestCase;
+use iamfarhad\LaravelAuditLog\Traits\Auditable;
+use iamfarhad\LaravelAuditLog\Transformers\MaskEmailTransformer;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
+
+final class AdvancedAuditFeaturesTest extends TestCase
+{
+    public function test_can_search_timeline_diff_and_analytics(): void
+    {
+        config(['audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']]]);
+
+        $user = AdvancedAuditUser::create([
+            'name' => 'Farhad',
+            'email' => 'farhad@example.com',
+            'password' => 'secret',
+        ]);
+
+        $user->update(['name' => 'Farhad Zand']);
+
+        $searchResults = AuditLoggerFacade::search(AdvancedAuditUser::class, 'Farhad Zand')->get();
+        $timeline = $user->auditTimeline();
+        $diff = $user->auditDiff();
+        $summary = AuditLoggerFacade::analytics()->summary(AdvancedAuditUser::class);
+
+        $this->assertCount(1, $searchResults);
+        $this->assertCount(2, $timeline);
+        $this->assertSame('updated', $timeline->last()['action']);
+        $this->assertSame('name', $diff[0]['field']);
+        $this->assertSame('Farhad', $diff[0]['old']);
+        $this->assertSame('Farhad Zand', $diff[0]['new']);
+        $this->assertSame(2, $summary['total']);
+        $this->assertSame(1, $summary['actions']['created']);
+        $this->assertSame(1, $summary['actions']['updated']);
+    }
+
+    public function test_can_restore_and_rollback_without_saving(): void
+    {
+        config(['audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']]]);
+
+        $user = AdvancedAuditUser::create([
+            'name' => 'Original',
+            'email' => 'restore@example.com',
+            'password' => 'secret',
+        ]);
+
+        $user->update(['name' => 'Changed']);
+
+        /** @var EloquentAuditLog $updateLog */
+        $updateLog = $user->auditLogs()->where('action', 'updated')->firstOrFail();
+
+        $preview = $user->previewRestore($updateLog, 'rollback');
+        $user->rollbackToAudit($updateLog, false);
+
+        $this->assertSame('name', $preview[0]['field']);
+        $this->assertSame('Original', $preview[0]['target']);
+        $this->assertSame('Original', $user->name);
+
+        $user->restoreFromAudit($updateLog, false);
+
+        $this->assertSame('Changed', $user->name);
+    }
+
+    public function test_field_transformers_and_redactors_are_applied(): void
+    {
+        config([
+            'audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']],
+            'audit-logger.fields.redact' => ['name'],
+            'audit-logger.fields.transformers' => [
+                'email' => MaskEmailTransformer::class,
+            ],
+        ]);
+
+        $user = AdvancedAuditUser::create([
+            'name' => 'Sensitive Name',
+            'email' => 'private@example.com',
+            'password' => 'secret',
+        ]);
+
+        /** @var EloquentAuditLog $log */
+        $log = $user->auditLogs()->where('action', 'created')->firstOrFail();
+
+        $this->assertSame('[REDACTED]', $log->new_values['name']);
+        $this->assertSame('p******@example.com', $log->new_values['email']);
+        $this->assertArrayNotHasKey('password', $log->new_values);
+    }
+
+    public function test_tamper_evident_hash_chain_can_be_verified(): void
+    {
+        config([
+            'audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']],
+            'audit-logger.security.hashing.enabled' => true,
+            'audit-logger.security.hashing.key' => 'test-key',
+        ]);
+
+        $user = AdvancedAuditUser::create([
+            'name' => 'Hash One',
+            'email' => 'hash@example.com',
+            'password' => 'secret',
+        ]);
+        $user->update(['name' => 'Hash Two']);
+
+        $validResult = AuditLoggerFacade::verifyHashChain(AdvancedAuditUser::class);
+
+        $this->assertTrue($validResult['valid']);
+        $this->assertSame(2, $validResult['checked']);
+        $this->assertNotNull($user->auditLogs()->where('action', 'updated')->first()->audit_hash);
+
+        DB::connection('testbench')
+            ->table('audit_users_logs')
+            ->where('action', 'updated')
+            ->update(['new_values' => json_encode(['name' => 'Tampered'], JSON_THROW_ON_ERROR)]);
+
+        $invalidResult = AuditLoggerFacade::verifyHashChain(AdvancedAuditUser::class);
+
+        $this->assertFalse($invalidResult['valid']);
+        $this->assertCount(1, $invalidResult['failures']);
+    }
+
+    public function test_postgresql_driver_can_be_resolved(): void
+    {
+        $logger = \iamfarhad\LaravelAuditLog\Services\AuditLogger::getDriver('postgresql', 'testbench');
+
+        $this->assertInstanceOf(\iamfarhad\LaravelAuditLog\Services\AuditLogger::class, $logger);
+    }
+}
+
+final class AdvancedAuditUser extends Model
+{
+    use Auditable;
+
+    protected $table = 'users';
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+    ];
+}

--- a/tests/Feature/AdvancedAuditFeaturesTest.php
+++ b/tests/Feature/AdvancedAuditFeaturesTest.php
@@ -16,9 +16,7 @@ final class AdvancedAuditFeaturesTest extends TestCase
 {
     public function test_can_search_timeline_diff_and_analytics(): void
     {
-        config(['audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']]]);
-
-        $user = AdvancedAuditUser::create([
+        $user = User::create([
             'name' => 'Farhad',
             'email' => 'farhad@example.com',
             'password' => 'secret',
@@ -26,10 +24,10 @@ final class AdvancedAuditFeaturesTest extends TestCase
 
         $user->update(['name' => 'Farhad Zand']);
 
-        $searchResults = AuditLoggerFacade::search(AdvancedAuditUser::class, 'Farhad Zand')->get();
+        $searchResults = AuditLoggerFacade::search(User::class, 'Farhad Zand')->get();
         $timeline = $user->auditTimeline();
         $diff = $user->auditDiff();
-        $summary = AuditLoggerFacade::analytics()->summary(AdvancedAuditUser::class);
+        $summary = AuditLoggerFacade::analytics()->summary(User::class);
 
         $this->assertCount(1, $searchResults);
         $this->assertCount(2, $timeline);
@@ -44,9 +42,7 @@ final class AdvancedAuditFeaturesTest extends TestCase
 
     public function test_can_restore_and_rollback_without_saving(): void
     {
-        config(['audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']]]);
-
-        $user = AdvancedAuditUser::create([
+        $user = User::create([
             'name' => 'Original',
             'email' => 'restore@example.com',
             'password' => 'secret',
@@ -72,14 +68,13 @@ final class AdvancedAuditFeaturesTest extends TestCase
     public function test_field_transformers_and_redactors_are_applied(): void
     {
         config([
-            'audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']],
             'audit-logger.fields.redact' => ['name'],
             'audit-logger.fields.transformers' => [
                 'email' => MaskEmailTransformer::class,
             ],
         ]);
 
-        $user = AdvancedAuditUser::create([
+        $user = User::create([
             'name' => 'Sensitive Name',
             'email' => 'private@example.com',
             'password' => 'secret',
@@ -96,19 +91,18 @@ final class AdvancedAuditFeaturesTest extends TestCase
     public function test_tamper_evident_hash_chain_can_be_verified(): void
     {
         config([
-            'audit-logger.entities' => [AdvancedAuditUser::class => ['audit_table' => 'audit_users_logs']],
             'audit-logger.security.hashing.enabled' => true,
             'audit-logger.security.hashing.key' => 'test-key',
         ]);
 
-        $user = AdvancedAuditUser::create([
+        $user = User::create([
             'name' => 'Hash One',
             'email' => 'hash@example.com',
             'password' => 'secret',
         ]);
         $user->update(['name' => 'Hash Two']);
 
-        $validResult = AuditLoggerFacade::verifyHashChain(AdvancedAuditUser::class);
+        $validResult = AuditLoggerFacade::verifyHashChain(User::class);
 
         $this->assertTrue($validResult['valid']);
         $this->assertSame(2, $validResult['checked']);
@@ -119,7 +113,7 @@ final class AdvancedAuditFeaturesTest extends TestCase
             ->where('action', 'updated')
             ->update(['new_values' => json_encode(['name' => 'Tampered'], JSON_THROW_ON_ERROR)]);
 
-        $invalidResult = AuditLoggerFacade::verifyHashChain(AdvancedAuditUser::class);
+        $invalidResult = AuditLoggerFacade::verifyHashChain(User::class);
 
         $this->assertFalse($invalidResult['valid']);
         $this->assertCount(1, $invalidResult['failures']);
@@ -133,7 +127,7 @@ final class AdvancedAuditFeaturesTest extends TestCase
     }
 }
 
-final class AdvancedAuditUser extends Model
+final class User extends Model
 {
     use Auditable;
 

--- a/tests/Feature/AdvancedAuditFeaturesTest.php
+++ b/tests/Feature/AdvancedAuditFeaturesTest.php
@@ -6,6 +6,7 @@ namespace iamfarhad\LaravelAuditLog\Tests\Feature;
 
 use iamfarhad\LaravelAuditLog\Facades\AuditLogger as AuditLoggerFacade;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditLogger;
 use iamfarhad\LaravelAuditLog\Tests\TestCase;
 use iamfarhad\LaravelAuditLog\Traits\Auditable;
 use iamfarhad\LaravelAuditLog\Transformers\MaskEmailTransformer;
@@ -121,9 +122,9 @@ final class AdvancedAuditFeaturesTest extends TestCase
 
     public function test_postgresql_driver_can_be_resolved(): void
     {
-        $logger = \iamfarhad\LaravelAuditLog\Services\AuditLogger::getDriver('postgresql', 'testbench');
+        $logger = AuditLogger::getDriver('postgresql', 'testbench');
 
-        $this->assertInstanceOf(\iamfarhad\LaravelAuditLog\Services\AuditLogger::class, $logger);
+        $this->assertInstanceOf(AuditLogger::class, $logger);
     }
 }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,21 +14,16 @@ abstract class TestCase extends Orchestra
     protected function setUp(): void
     {
         parent::setUp();
-
-        // Run the migrations
         $this->setUpDatabase();
     }
 
     protected function getPackageProviders($app): array
     {
-        return [
-            AuditLoggerServiceProvider::class,
-        ];
+        return [AuditLoggerServiceProvider::class];
     }
 
     protected function getEnvironmentSetUp($app): void
     {
-        // Setup default database to use sqlite :memory:
         $app['config']->set('database.default', 'testbench');
         $app['config']->set('database.connections.testbench', [
             'driver' => 'sqlite',
@@ -36,25 +31,24 @@ abstract class TestCase extends Orchestra
             'prefix' => '',
         ]);
 
-        // Configure audit logger
         $app['config']->set('audit-logger.default', 'mysql');
         $app['config']->set('audit-logger.drivers.mysql.connection', 'testbench');
-
-        // Disable auto migration since we'll create the tables manually in setUpDatabase
+        $app['config']->set('audit-logger.drivers.postgresql.connection', 'testbench');
         $app['config']->set('audit-logger.auto_migration', false);
         $app['config']->set('audit-logger.batch.enabled', false);
-
-        // Set global excluded fields
+        $app['config']->set('audit-logger.security.hashing.enabled', false);
         $app['config']->set('audit-logger.fields.exclude', [
+            'password',
             'remember_token',
             'updated_at',
             'created_at',
         ]);
+        $app['config']->set('audit-logger.fields.redact', []);
+        $app['config']->set('audit-logger.fields.transformers', []);
     }
 
     protected function setUpDatabase(): void
     {
-        // Create users table
         Schema::connection('testbench')->create('users', function (Blueprint $table) {
             $table->id();
             $table->string('name');
@@ -66,24 +60,17 @@ abstract class TestCase extends Orchestra
             $table->timestamps();
         });
 
-        // Create posts table
         Schema::connection('testbench')->create('posts', function (Blueprint $table) {
             $table->id();
             $table->foreignId('user_id')->constrained()->onDelete('cascade');
             $table->string('title');
             $table->text('content');
-            $table->string('status')->default('draft'); // draft, published, archived
+            $table->string('status')->default('draft');
             $table->timestamp('published_at')->nullable();
             $table->timestamps();
         });
 
-        // Create model-specific audit tables
-        $auditTables = [
-            'audit_users_logs',
-            'audit_posts_logs',
-        ];
-
-        foreach ($auditTables as $tableName) {
+        foreach (['audit_users_logs', 'audit_posts_logs'] as $tableName) {
             Schema::connection('testbench')->create($tableName, function (Blueprint $table) {
                 $table->id();
                 $table->string('entity_id');
@@ -95,10 +82,14 @@ abstract class TestCase extends Orchestra
                 $table->json('metadata')->nullable();
                 $table->timestamp('created_at');
                 $table->string('source')->nullable();
-
+                $table->string('audit_hash', 128)->nullable();
+                $table->string('previous_hash', 128)->nullable();
+                $table->timestamp('anonymized_at')->nullable();
                 $table->index('entity_id');
                 $table->index(['causer_type', 'causer_id']);
                 $table->index('created_at');
+                $table->index('audit_hash');
+                $table->index('previous_hash');
             });
         }
     }


### PR DESCRIPTION
## Summary

This PR implements the requested advanced audit features:

- Add audit search query builder via `AuditLogger::query()` and `AuditLogger::search()`
- Add analytics service for summaries, top actions, top causers, top changed entities, and changes per day
- Add model-facing timeline and diff APIs: `auditTimeline()`, `auditDiff()`, and `auditHistory()`
- Add restore/replay/rollback APIs: `restoreFromAudit()`, `rollbackToAudit()`, and `previewRestore()`
- Add tamper-evident HMAC hash chain support with `audit_hash` and `previous_hash`
- Add hash-chain verification via `AuditLogger::verifyHashChain()`
- Add field redaction and transformer support with default mask/hash transformers
- Fix PostgreSQL driver resolution in `AuditLogger::getDriver()` and service provider wiring
- Align MySQL and PostgreSQL storage with hash-chain columns
- Add feature tests for search, analytics, timeline/diff, restore/rollback, redaction/transformers, hash verification, and PostgreSQL driver resolution
- Update `README.md` with advanced feature examples, security guidance, and comparison table
- Add `docs/advanced-audit-features.md` with extended examples and hash-chain upgrade guidance

## Backward compatibility / upgrade notes

- Hash-chain mode remains disabled by default via `AUDIT_HASH_CHAIN_ENABLED=false`.
- Existing audit tables continue to work with hashing disabled.
- Existing projects that want hash-chain verification must first add nullable `audit_hash` and `previous_hash` columns to every existing audit table. The upgrade guide includes a sample migration.
- `verifyHashChain()` returns structured failures for missing tables/columns instead of throwing database exceptions.
- Custom `audit_table` / `table` config values are respected as-is; prefix/suffix generation is only used for default audit table names.

## Review fixes

Addressed Gemini Code Assist feedback and follow-up maintainer review issues:

- Cast JSON/JSONB columns to text for PostgreSQL audit search in both `AuditQuery` and `EloquentAuditLog::scopeSearch()`.
- Use the audited model connection grammar when wrapping JSON columns, instead of the default DB connection grammar.
- Recursively sort hash payload arrays before serialization for deterministic hashes across JSON and JSONB storage.
- Decode Laravel `base64:` app keys before HMAC calculation.
- Stream hash verification rows using `lazy()` with a manual checked counter.
- Respect fully custom audit table names in model and driver table resolution.
- Avoid overriding Eloquent's `getKey()` method from the `Auditable` trait.
- Validate object-form audit logs before restore/rollback so a log from another model/table/entity cannot be applied accidentally.
- Remove stale driver config caching while keeping table-existence caching.

## Verification

Latest checks on head `9187616ea956e70c425b8eb5c1e0ab467c863ad9`:

- `Coding Standards`: passed
- `run-tests`: passed across the full PHP/Laravel matrix