### PR TITLE
Add v2 major release audit infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,61 +6,70 @@
 [![Laravel Version](https://img.shields.io/badge/Laravel-10.x%7C11.x%7C12.x%7C13.x-red.svg?style=flat-square)](https://laravel.com/)
 [![License](https://img.shields.io/packagist/l/iamfarhad/laravel-audit-log.svg?style=flat-square)](https://packagist.org/packages/iamfarhad/laravel-audit-log)
 
-**Laravel Audit Logger** is a high-performance, compliance-ready audit logging package for Laravel applications. It tracks Eloquent model changes with entity-specific audit tables, source tracking, queue support, retention policies, timeline/diff APIs, restore/replay helpers, field redaction, and optional tamper-evident hash chains.
+**Laravel Audit Logger** is a compliance-ready audit trail package for Laravel. It stores model changes in dedicated audit tables, supports searchable timelines and diffs, provides restore/replay helpers, protects sensitive fields, and can verify tamper-evident hash chains.
 
-The package is designed for serious audit trails in SaaS, ecommerce, admin panels, financial systems, and enterprise Laravel apps where audit data must be searchable, understandable, and trustworthy.
+The v2 infrastructure adds production migration tooling, native batch inserts, multi-tenancy, append-only audit rows, relationship auditing helpers, operational Artisan commands, API resources, authorization helpers, snapshots, and lifecycle events.
+
+Use it when audit data is more than a simple activity feed: SaaS platforms, marketplaces, fintech/admin systems, back-office tools, enterprise applications, and any Laravel app where changes must be explainable, searchable, and trustworthy.
 
 ## Table of Contents
 
-- [Features](#features)
-- [Why Laravel Audit Logger?](#why-laravel-audit-logger)
+- [Highlights](#highlights)
+- [Why this package?](#why-this-package)
 - [Requirements](#requirements)
 - [Installation](#installation)
 - [Quick Start](#quick-start)
 - [Configuration](#configuration)
-- [Advanced Features](#advanced-features)
-  - [Audit Search](#audit-search)
-  - [Analytics](#analytics)
-  - [Timeline and Diff API](#timeline-and-diff-api)
-  - [Restore, Replay, and Rollback](#restore-replay-and-rollback)
-  - [Tamper-Evident Hash Chain](#tamper-evident-hash-chain)
-  - [Field Redaction and Transformers](#field-redaction-and-transformers)
-  - [Source Tracking](#source-tracking)
-  - [Queue Processing](#queue-processing)
-  - [Retention Policies](#retention-policies)
+- [Production Table Management](#production-table-management)
+- [Search, Analytics, Timeline, and Diff](#search-analytics-timeline-and-diff)
+- [Restore, Replay, and Rollback](#restore-replay-and-rollback)
+- [Security and Integrity](#security-and-integrity)
+- [Privacy: Redaction and Transformers](#privacy-redaction-and-transformers)
+- [Multi-Tenancy](#multi-tenancy)
+- [Batch Inserts](#batch-inserts)
+- [Relationship Auditing](#relationship-auditing)
+- [Snapshots](#snapshots)
+- [API Resources](#api-resources)
+- [Operational Commands](#operational-commands)
+- [Retention Policies](#retention-policies)
+- [Events](#events)
+- [Upgrade Notes](#upgrade-notes)
 - [Comparison](#comparison)
 - [Testing](#testing)
-- [Security Best Practices](#security-best-practices)
 - [Troubleshooting](#troubleshooting)
+- [Documentation](#documentation)
 - [Contributing](#contributing)
 - [License](#license)
 
-## Features
+## Highlights
 
-- **Entity-specific audit tables**: Stores each model's audit trail in a dedicated table such as `audit_orders_logs` for faster querying and simpler retention.
-- **CRUD and restore tracking**: Captures `created`, `updated`, `deleted`, and `restored` model events.
-- **Old/new value storage**: Stores before-and-after values in JSON/JSONB columns.
-- **Source tracking**: Records whether the change came from an HTTP controller, Artisan command, queue worker, or background job context.
-- **User/causer tracking**: Resolves the authenticated user with configurable guard/model/resolver support.
-- **Audit search API**: Search audit rows across entity id, action, source, causer, metadata, and changed values.
-- **Analytics helpers**: Summary counts, top actions, top causers, top changed entities, and changes per day.
-- **Timeline and diff API**: Generate presentation-friendly audit timelines and field-level diffs for admin panels.
-- **Restore/replay API**: Restore a model from a previous audit entry or roll it back to old values.
-- **Tamper-evident hash chain**: Optional HMAC chain using `audit_hash` and `previous_hash` to detect audit row tampering.
-- **Field redaction and transformers**: Mask, hash, redact, or normalize sensitive values before they are stored.
-- **Queue support**: Run audit writes synchronously or asynchronously.
-- **Retention policies**: Delete, anonymize, or archive old audit logs globally or per model.
-- **MySQL and PostgreSQL drivers**: MySQL uses JSON columns; PostgreSQL uses JSONB columns.
-- **Modern Laravel support**: Laravel 10, 11, 12, and 13 with PHP 8.1+.
+- **Entity-specific audit tables**: Store each model's audit history in its own table, such as `audit_orders_logs`.
+- **Automatic model auditing**: Capture created, updated, deleted, restored, and custom relationship audit actions.
+- **Searchable audit trails**: Search by action, source, causer, entity id, metadata, old values, and new values.
+- **Analytics helpers**: Build dashboards with summaries, top actions, top causers, changed entities, and daily activity.
+- **Timeline and diff APIs**: Render admin-friendly history views and field-level changes.
+- **Restore/replay/rollback APIs**: Restore a model from audit history or preview changes before saving.
+- **Tamper-evident hash chain**: Optional HMAC chain using `audit_hash` and `previous_hash`.
+- **Append-only mode**: Prevent Eloquent updates and deletes on audit log rows.
+- **Privacy controls**: Exclude, redact, mask, hash, or transform sensitive fields before storage.
+- **Production migration tooling**: Generate and create audit tables with Artisan commands.
+- **Multi-tenancy**: Store tenant context on every audit row when enabled.
+- **Native batch inserts**: Insert large audit batches efficiently when queueing and hash-chain mode are off.
+- **Relationship auditing**: Explicit helpers for attach, detach, and sync workflows.
+- **API resources**: Consistent JSON resources for audit logs, timelines, and diffs.
+- **Operational commands**: Doctor checks, config validation, stats, timeline, diff, verify, upgrade, and partition guidance.
+- **MySQL and PostgreSQL support**: JSON for MySQL and JSONB for PostgreSQL.
 
-## Why Laravel Audit Logger?
+## Why this package?
 
-Most Laravel logging packages are optimized for general activity feeds. This package is optimized for audit infrastructure:
+Most Laravel activity packages are optimized for feeds. Laravel Audit Logger is optimized for **audit infrastructure**:
 
-- dedicated audit tables per entity for performance and isolation;
-- strong compliance features such as retention, anonymization, and hash-chain verification;
-- ergonomic APIs for searching, timeline rendering, diffs, and rollback workflows;
-- clean extension points for custom causer resolvers, storage drivers, metadata, and field transformers.
+- dedicated audit tables improve isolation and long-term query performance;
+- source tracking explains where a change came from;
+- restore and rollback APIs support operational recovery workflows;
+- hash-chain verification helps detect tampering;
+- v2 commands help production teams validate, migrate, inspect, and operate audit tables;
+- sensitive data controls reduce accidental PII or secret exposure.
 
 ## Requirements
 
@@ -114,13 +123,15 @@ final class Order extends Model
 }
 ```
 
-The package will automatically log model changes into a table such as:
+After that, create/update/delete/restore operations are recorded automatically.
+
+By default, the package stores order audit rows in:
 
 ```text
 audit_orders_logs
 ```
 
-Example audit row:
+A typical audit row contains:
 
 ```php
 [
@@ -137,13 +148,14 @@ Example audit row:
 
 ## Configuration
 
-A typical configuration looks like this:
+A compact configuration example:
 
 ```php
 return [
     'enabled' => env('AUDIT_ENABLED', true),
-
+    'preset' => env('AUDIT_PRESET', 'basic'),
     'default' => env('AUDIT_DRIVER', 'mysql'),
+    'auto_migration' => env('AUDIT_AUTO_MIGRATION', true),
 
     'drivers' => [
         'mysql' => [
@@ -151,7 +163,6 @@ return [
             'table_prefix' => env('AUDIT_TABLE_PREFIX', 'audit_'),
             'table_suffix' => env('AUDIT_TABLE_SUFFIX', '_logs'),
         ],
-
         'postgresql' => [
             'connection' => env('AUDIT_PGSQL_CONNECTION', config('database.default')),
             'table_prefix' => env('AUDIT_TABLE_PREFIX', 'audit_'),
@@ -166,28 +177,13 @@ return [
         'delay' => env('AUDIT_QUEUE_DELAY', 0),
     ],
 
-    'auto_migration' => env('AUDIT_AUTO_MIGRATION', true),
-
-    'fields' => [
-        'exclude' => [
-            'password',
-            'remember_token',
-            'api_token',
-            'secret',
-            'token',
-            'private_key',
-            'access_token',
-            'refresh_token',
-            'api_key',
-            'secret_key',
-        ],
-        'include_timestamps' => true,
-        'redact' => [],
-        'redaction_replacement' => env('AUDIT_REDACTION_REPLACEMENT', '[REDACTED]'),
-        'transformers' => [],
+    'batch' => [
+        'enabled' => env('AUDIT_BATCH_ENABLED', false),
+        'size' => env('AUDIT_BATCH_SIZE', 500),
     ],
 
     'security' => [
+        'append_only' => env('AUDIT_APPEND_ONLY', false),
         'hashing' => [
             'enabled' => env('AUDIT_HASH_CHAIN_ENABLED', false),
             'algorithm' => env('AUDIT_HASH_ALGORITHM', 'sha256'),
@@ -195,21 +191,82 @@ return [
         ],
     ],
 
-    'causer' => [
-        'guard' => null,
-        'model' => null,
-        'resolver' => null,
+    'tenant' => [
+        'enabled' => env('AUDIT_TENANT_ENABLED', false),
+        'resolver' => \iamfarhad\LaravelAuditLog\Services\TenantResolver::class,
+        'columns' => ['type' => 'tenant_type', 'id' => 'tenant_id'],
+    ],
+
+    'fields' => [
+        'exclude' => ['password', 'remember_token', 'api_token', 'secret', 'token'],
+        'include_timestamps' => true,
+        'redact' => [],
+        'redaction_replacement' => env('AUDIT_REDACTION_REPLACEMENT', '[REDACTED]'),
+        'transformers' => [],
+    ],
+
+    'entities' => [
+        // App\Models\Order::class => [
+        //     'audit_table' => 'audit_orders_logs',
+        //     'exclude' => ['internal_notes'],
+        //     'relations' => ['items', 'tags'],
+        // ],
     ],
 ];
 ```
 
-## Advanced Features
+## Production Table Management
 
-For the full advanced guide, see [`docs/advanced-audit-features.md`](docs/advanced-audit-features.md).
+Runtime auto-migration is convenient for local development. Production apps should prefer generated migrations or explicit table creation.
 
-### Audit Search
+Generate a migration for one audited model:
 
-Search audit logs with a fluent query API:
+```bash
+php artisan audit:make-migration App\Models\Order
+```
+
+Create audit tables for all configured entities:
+
+```bash
+php artisan audit:migrate
+```
+
+Create storage for one entity:
+
+```bash
+php artisan audit:migrate --entity=App\Models\Order
+```
+
+Disable runtime auto-migration in production after your migrations are deployed:
+
+```env
+AUDIT_AUTO_MIGRATION=false
+```
+
+The v2 audit table shape includes optional support columns:
+
+```text
+id
+entity_id
+action
+old_values
+new_values
+changes
+causer_type
+causer_id
+tenant_type
+tenant_id
+metadata
+created_at
+source
+audit_hash
+previous_hash
+anonymized_at
+```
+
+## Search, Analytics, Timeline, and Diff
+
+### Search
 
 ```php
 use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
@@ -240,17 +297,13 @@ $topChangedEntities = AuditLogger::analytics()->topChangedEntities(App\Models\Or
 $changesPerDay = AuditLogger::analytics()->changesPerDay(App\Models\Order::class, 30);
 ```
 
-### Timeline and Diff API
-
-Every auditable model can expose a timeline and field-level diff:
+### Timeline
 
 ```php
 $timeline = $order->auditTimeline();
-$latestDiff = $order->auditDiff();
-$specificDiff = $order->auditDiff($auditLogId);
 ```
 
-A timeline entry includes:
+Timeline entries are suitable for admin panels:
 
 ```php
 [
@@ -264,35 +317,60 @@ A timeline entry includes:
     'changes' => [
         ['field' => 'status', 'old' => 'pending', 'new' => 'approved'],
     ],
-    'metadata' => [],
-    'audit_hash' => '...',
-    'previous_hash' => '...',
 ]
 ```
 
-### Restore, Replay, and Rollback
+### Diff
 
-Replay the new values from an audit log:
+```php
+$latestDiff = $order->auditDiff();
+$specificDiff = $order->auditDiff($auditLogId);
+```
+
+## Restore, Replay, and Rollback
+
+Restore/replay new values from an audit log:
 
 ```php
 $order->restoreFromAudit($auditLogId);
 ```
 
-Rollback to the old values captured by an audit log:
+Rollback to old values:
 
 ```php
 $order->rollbackToAudit($auditLogId);
 ```
 
-Preview a restore/rollback before saving:
+Preview before saving:
 
 ```php
 $preview = $order->previewRestore($auditLogId, 'rollback');
 ```
 
-### Tamper-Evident Hash Chain
+Restore safety options:
 
-Enable hash-chain verification:
+```env
+AUDIT_RESTORE_VALIDATE_FILLABLE=true
+AUDIT_RESTORE_AUDIT=true
+```
+
+- `AUDIT_RESTORE_VALIDATE_FILLABLE=true` only applies fields listed in the model's `$fillable` array.
+- `AUDIT_RESTORE_AUDIT=false` saves the restored model without creating another audit row.
+- Authorization can be enabled with `AUDIT_AUTHORIZATION_ENABLED=true`.
+
+## Security and Integrity
+
+### Append-only mode
+
+```env
+AUDIT_APPEND_ONLY=true
+```
+
+When enabled, Eloquent update/delete operations on `EloquentAuditLog` are blocked.
+
+### Hash-chain mode
+
+Hash-chain mode is disabled by default and must be enabled explicitly:
 
 ```env
 AUDIT_HASH_CHAIN_ENABLED=true
@@ -302,10 +380,10 @@ AUDIT_HASH_KEY=your-private-audit-key
 
 When enabled, every audit row stores:
 
-- `previous_hash`: the previous audit row hash for the same audit table;
-- `audit_hash`: an HMAC of the canonical audit payload plus `previous_hash`.
+- `previous_hash`: previous row hash in the same audit table;
+- `audit_hash`: HMAC of the canonical audit payload plus `previous_hash`.
 
-Verify an audit chain:
+Verify a chain:
 
 ```php
 $result = AuditLogger::verifyHashChain(App\Models\Order::class);
@@ -315,9 +393,27 @@ if (! $result['valid']) {
 }
 ```
 
-### Field Redaction and Transformers
+Or use Artisan:
 
-Redact sensitive fields with a fixed replacement:
+```bash
+php artisan audit:verify App\Models\Order
+php artisan audit:verify App\Models\Order --entity-id=123
+php artisan audit:verify App\Models\Order --fail-on-missing-hash
+```
+
+Native batch inserts are automatically skipped when hash-chain mode is enabled, because each row must be chained sequentially.
+
+## Privacy: Redaction and Transformers
+
+Exclude fields completely:
+
+```php
+'fields' => [
+    'exclude' => ['password', 'remember_token', 'api_token'],
+],
+```
+
+Redact fields with a fixed replacement:
 
 ```php
 'fields' => [
@@ -326,7 +422,7 @@ Redact sensitive fields with a fixed replacement:
 ],
 ```
 
-Transform fields before storage:
+Transform values before storage:
 
 ```php
 'fields' => [
@@ -338,7 +434,7 @@ Transform fields before storage:
 ],
 ```
 
-Create a custom transformer:
+Custom transformer:
 
 ```php
 <?php
@@ -359,43 +455,181 @@ final class MoneyTransformer implements FieldTransformerInterface
 }
 ```
 
-### Source Tracking
+## Multi-Tenancy
 
-The package automatically records where a change came from:
-
-- HTTP controller action, such as `App\Http\Controllers\OrderController@update`
-- Artisan command, such as `orders:process`
-- Queue/background job context when available
-
-Use source scopes:
-
-```php
-$httpLogs = EloquentAuditLog::forEntity(Order::class)->fromHttp()->get();
-$consoleLogs = EloquentAuditLog::forEntity(Order::class)->fromConsole()->get();
-$commandLogs = EloquentAuditLog::forEntity(Order::class)->fromCommand('orders:process')->get();
-```
-
-### Queue Processing
-
-Enable queue processing:
+Enable tenant context:
 
 ```env
-AUDIT_QUEUE_ENABLED=true
-AUDIT_QUEUE_CONNECTION=redis
-AUDIT_QUEUE_NAME=audit
+AUDIT_TENANT_ENABLED=true
 ```
 
-Run an audit worker:
-
-```bash
-php artisan queue:work --queue=audit --tries=3 --timeout=60
-```
-
-### Retention Policies
-
-The package supports delete, anonymize, and archive strategies:
+Create a resolver:
 
 ```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Audit;
+
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
+
+final class CurrentTenantResolver implements TenantResolverInterface
+{
+    public function resolve(): array
+    {
+        $tenant = tenant();
+
+        return [
+            'type' => $tenant?->getMorphClass(),
+            'id' => $tenant?->getKey(),
+        ];
+    }
+}
+```
+
+Configure it:
+
+```php
+'tenant' => [
+    'enabled' => true,
+    'resolver' => App\Audit\CurrentTenantResolver::class,
+    'columns' => [
+        'type' => 'tenant_type',
+        'id' => 'tenant_id',
+    ],
+],
+```
+
+Query by tenant:
+
+```php
+$logs = EloquentAuditLog::forEntity(Order::class)
+    ->forTenant($tenant->id, $tenant::class)
+    ->latest()
+    ->get();
+```
+
+## Batch Inserts
+
+Batch mode is useful for imports, backfills, and high-volume programmatic audit creation.
+
+```env
+AUDIT_BATCH_ENABLED=true
+AUDIT_BATCH_SIZE=500
+AUDIT_QUEUE_ENABLED=false
+```
+
+```php
+AuditLogger::batch([
+    AuditLog::fromArray([...]),
+    AuditLog::fromArray([...]),
+]);
+```
+
+Rules:
+
+- native batch mode only runs when queueing is disabled;
+- native batch mode is skipped when hash-chain mode is enabled;
+- rows are grouped by audit table and inserted in chunks.
+
+## Relationship Auditing
+
+The package provides explicit helpers for relation changes. It does not monkey-patch Laravel relationship methods.
+
+```php
+use iamfarhad\LaravelAuditLog\Services\RelationshipAuditor;
+
+app(RelationshipAuditor::class)->attached($user, 'roles', [$roleId]);
+app(RelationshipAuditor::class)->detached($user, 'roles', [$roleId]);
+app(RelationshipAuditor::class)->synced($user, 'roles', $roleIds);
+```
+
+Example actions:
+
+```text
+roles_attached
+roles_detached
+roles_synced
+```
+
+## Snapshots
+
+Snapshots let you periodically store a full model state for faster reconstruction.
+
+```env
+AUDIT_SNAPSHOTS_ENABLED=true
+AUDIT_SNAPSHOT_EVERY=20
+```
+
+Manual snapshot:
+
+```php
+app(\iamfarhad\LaravelAuditLog\Services\AuditSnapshotService::class)->snapshot($order);
+```
+
+Automatic snapshot helper:
+
+```php
+app(\iamfarhad\LaravelAuditLog\Services\AuditSnapshotService::class)->maybeSnapshot($order);
+```
+
+Snapshot rows use action:
+
+```text
+snapshot
+```
+
+## API Resources
+
+Use resources to expose audit data from your own controllers:
+
+```php
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditLogResource;
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditTimelineResource;
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditDiffResource;
+
+return AuditLogResource::collection(
+    AuditLogger::query(Order::class)->latest()->paginate()
+);
+```
+
+Timeline and diff resources are available for UI/API responses:
+
+```php
+return AuditTimelineResource::collection($order->auditTimeline());
+return AuditDiffResource::collection($order->auditDiff($auditLogId));
+```
+
+## Operational Commands
+
+| Command | Purpose |
+|---|---|
+| `audit:make-migration App\Models\Order` | Generate a production audit table migration |
+| `audit:migrate` | Create audit storage for configured entities |
+| `audit:migrate --entity=App\Models\Order` | Create storage for one entity |
+| `audit:config-check` | Validate audit config, transformers, resolver, and hash settings |
+| `audit:doctor` | Check configured entities and audit tables |
+| `audit:stats App\Models\Order` | Show summary statistics |
+| `audit:timeline App\Models\Order 123` | Print timeline rows for one entity id |
+| `audit:diff App\Models\Order 456` | Print field-level changes for one audit row |
+| `audit:verify App\Models\Order` | Verify hash-chain integrity |
+| `audit:partition audit_orders_logs --monthly` | Show partitioning guidance |
+| `audit:upgrade v1-to-v2 --dry-run` | Report missing v2 columns |
+| `audit:cleanup --dry-run` | Preview retention cleanup |
+
+## Retention Policies
+
+Configure global or per-entity retention.
+
+```php
+'retention' => [
+    'enabled' => env('AUDIT_RETENTION_ENABLED', false),
+    'days' => env('AUDIT_RETENTION_DAYS', 365),
+    'strategy' => env('AUDIT_RETENTION_STRATEGY', 'delete'),
+    'batch_size' => env('AUDIT_RETENTION_BATCH_SIZE', 1000),
+],
+
 'entities' => [
     App\Models\User::class => [
         'retention' => [
@@ -408,12 +642,77 @@ The package supports delete, anonymize, and archive strategies:
 ],
 ```
 
-Run cleanup manually:
+Run cleanup:
 
 ```bash
 php artisan audit:cleanup --dry-run
 php artisan audit:cleanup --force
 ```
+
+## Events
+
+Listen to lifecycle events:
+
+```php
+use iamfarhad\LaravelAuditLog\Events\AuditCreated;
+use iamfarhad\LaravelAuditLog\Events\AuditCreating;
+use iamfarhad\LaravelAuditLog\Events\AuditVerificationFailed;
+
+Event::listen(AuditCreated::class, function (AuditCreated $event) {
+    // Send to internal security pipeline, metrics, or notifications.
+});
+```
+
+Available events:
+
+- `AuditCreating`
+- `AuditCreated`
+- `AuditVerificationFailed`
+
+## Upgrade Notes
+
+Check missing v2 columns:
+
+```bash
+php artisan audit:upgrade v1-to-v2 --dry-run
+```
+
+The command checks for:
+
+```text
+audit_hash
+previous_hash
+tenant_type
+tenant_id
+changes
+```
+
+Example migration for existing audit tables:
+
+```php
+Schema::table('audit_orders_logs', function (Blueprint $table): void {
+    $table->json('changes')->nullable()->after('new_values');
+    $table->string('tenant_type')->nullable()->after('causer_id');
+    $table->string('tenant_id')->nullable()->after('tenant_type');
+    $table->string('audit_hash', 128)->nullable()->after('source');
+    $table->string('previous_hash', 128)->nullable()->after('audit_hash');
+
+    $table->index('tenant_id');
+    $table->index(['tenant_id', 'created_at']);
+    $table->index('audit_hash');
+    $table->index('previous_hash');
+});
+```
+
+Recommended production upgrade order:
+
+1. Deploy code with new features disabled.
+2. Run `audit:upgrade v1-to-v2 --dry-run`.
+3. Add missing nullable columns through migrations.
+4. Enable tenant/change/snapshot features as needed.
+5. Enable hash-chain mode only after hash columns exist.
+6. Run `audit:doctor` and `audit:config-check`.
+7. Verify CI and monitor audit writes.
 
 ## Comparison
 
@@ -429,77 +728,104 @@ php artisan audit:cleanup --force
 | Timeline/diff API | Yes | Manual formatting | Auditable transition data |
 | Restore/replay API | Yes | No built-in model restore | Limited/manual workflows |
 | Tamper-evident hash chain | Yes | No | No |
+| Append-only mode | Yes | No | No |
+| Multi-tenancy context | Yes | Manual | Manual/resolver-based |
+| Native batch insert helper | Yes | No package-level helper | No package-level helper |
+| Relationship audit helper | Yes | Manual | Manual/custom |
+| API resources | Yes | No | No |
 | Field redactors/transformers | Yes | Custom pipes/manual | Attribute modifiers/resolvers |
 | Retention strategies | Delete, anonymize, archive | Manual cleanup | Manual cleanup |
+| Operational doctor command | Yes | No | No |
 
 ## Testing
 
-Run the test suite:
+Run tests:
 
 ```bash
 composer test
 ```
 
-Run static analysis and style checks:
+Run style checks:
 
 ```bash
-composer analyse
 composer pint:test
 ```
 
-Fix style automatically:
+Fix style:
 
 ```bash
 composer pint
 ```
 
-## Security Best Practices
+If your project has static analysis configured:
 
-- Exclude or redact secrets, tokens, passwords, API keys, and payment fields.
-- Use field transformers for PII that must be retained in masked or hashed form.
-- Store `AUDIT_HASH_KEY` securely and rotate it intentionally.
-- Restrict audit log access with Laravel policies/gates.
-- Use retention policies for privacy and compliance requirements.
-- Run `AuditLogger::verifyHashChain()` periodically if hash-chain mode is enabled.
+```bash
+composer analyse
+```
 
 ## Troubleshooting
 
 ### Audit tables are not created
 
-Check:
+For development, enable auto-migration:
 
-```php
-'audit-logger.auto_migration' => true
+```env
+AUDIT_AUTO_MIGRATION=true
 ```
 
-Or create storage manually through the configured driver.
+For production, generate and run migrations:
 
-### Causer is not recorded
+```bash
+php artisan audit:make-migration App\Models\Order
+php artisan migrate
+```
 
-Check that the user is authenticated during the operation, and verify your configured guard:
+Or create storage explicitly:
+
+```bash
+php artisan audit:migrate --entity=App\Models\Order
+```
+
+### Hash verification says columns are missing
+
+Add nullable `audit_hash` and `previous_hash` columns before enabling hash-chain verification.
+
+### Batch inserts are not used
+
+Native batch insert is intentionally skipped when:
+
+- `AUDIT_QUEUE_ENABLED=true`; or
+- `AUDIT_HASH_CHAIN_ENABLED=true`; or
+- `AUDIT_BATCH_ENABLED=false`.
+
+### Tenant fields are not stored
+
+Check all three:
+
+- `AUDIT_TENANT_ENABLED=true`
+- resolver implements `TenantResolverInterface`
+- audit table has `tenant_type` and `tenant_id` columns
+
+### Restore is blocked
+
+If authorization is enabled, define the configured gate:
 
 ```php
-'causer' => [
-    'guard' => 'web',
-]
+Gate::define('restoreFromAudit', fn ($user, $model) => $user->can('update', $model));
 ```
 
 ### Queued logs are missing
 
-Make sure queue workers are running:
+Run an audit queue worker:
 
 ```bash
-php artisan queue:work --queue=audit
+php artisan queue:work --queue=audit --tries=3 --timeout=60
 ```
 
-### Hash verification fails
+## Documentation
 
-Possible causes:
-
-- audit rows were edited manually;
-- `AUDIT_HASH_KEY` changed;
-- old rows existed before hash-chain mode was enabled;
-- records were imported without preserving hash order.
+- [Advanced audit features](docs/advanced-audit-features.md)
+- [v2 major release infrastructure](docs/v2-major-release.md)
 
 ## Contributing
 
@@ -510,7 +836,6 @@ Before opening a pull request:
 ```bash
 composer install
 composer test
-composer analyse
 composer pint:test
 ```
 

--- a/config/audit-logger.php
+++ b/config/audit-logger.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 return [
     'enabled' => env('AUDIT_ENABLED', true),
 
+    'preset' => env('AUDIT_PRESET', 'basic'),
+
     'default' => env('AUDIT_DRIVER', 'mysql'),
 
     'drivers' => [
@@ -26,6 +28,11 @@ return [
         'connection' => env('AUDIT_QUEUE_CONNECTION', config('queue.default')),
         'queue_name' => env('AUDIT_QUEUE_NAME', 'audit'),
         'delay' => env('AUDIT_QUEUE_DELAY', 0),
+    ],
+
+    'batch' => [
+        'enabled' => env('AUDIT_BATCH_ENABLED', false),
+        'size' => env('AUDIT_BATCH_SIZE', 500),
     ],
 
     'auto_migration' => env('AUDIT_AUTO_MIGRATION', true),
@@ -59,11 +66,42 @@ return [
     ],
 
     'security' => [
+        'append_only' => env('AUDIT_APPEND_ONLY', false),
         'hashing' => [
             'enabled' => env('AUDIT_HASH_CHAIN_ENABLED', false),
             'algorithm' => env('AUDIT_HASH_ALGORITHM', 'sha256'),
             'key' => env('AUDIT_HASH_KEY', env('APP_KEY')),
         ],
+    ],
+
+    'tenant' => [
+        'enabled' => env('AUDIT_TENANT_ENABLED', false),
+        'resolver' => \iamfarhad\LaravelAuditLog\Services\TenantResolver::class,
+        'columns' => [
+            'type' => 'tenant_type',
+            'id' => 'tenant_id',
+        ],
+    ],
+
+    'authorization' => [
+        'enabled' => env('AUDIT_AUTHORIZATION_ENABLED', false),
+        'view_gate' => 'viewAuditLogs',
+        'restore_gate' => 'restoreFromAudit',
+    ],
+
+    'changes' => [
+        'store' => env('AUDIT_STORE_CHANGES', false),
+        'column' => 'changes',
+    ],
+
+    'snapshots' => [
+        'enabled' => env('AUDIT_SNAPSHOTS_ENABLED', false),
+        'every' => env('AUDIT_SNAPSHOT_EVERY', 20),
+    ],
+
+    'restore' => [
+        'validate_fillable' => env('AUDIT_RESTORE_VALIDATE_FILLABLE', false),
+        'audit_restores' => env('AUDIT_RESTORE_AUDIT', true),
     ],
 
     'causer' => [
@@ -88,6 +126,7 @@ return [
         //     'audit_table' => 'audit_users_logs',
         //     'exclude' => ['password'],
         //     'include' => ['*'],
+        //     'relations' => ['roles', 'permissions'],
         //     'retention' => [
         //         'days' => 730,
         //         'strategy' => 'anonymize',

--- a/docs/v2-major-release.md
+++ b/docs/v2-major-release.md
@@ -1,0 +1,152 @@
+# v2 Major Release Infrastructure
+
+This guide covers the v2 infrastructure added on top of the advanced audit APIs.
+
+Excluded from this branch by design:
+
+- Filament plugin
+- Nova / Backpack integrations
+- New external storage drivers such as ClickHouse, OpenSearch, S3, and webhook drivers
+
+## Migration tooling
+
+Generate a production migration for one audited model:
+
+```bash
+php artisan audit:make-migration App\\Models\\Order
+```
+
+Create audit storage for configured entities:
+
+```bash
+php artisan audit:migrate
+php artisan audit:migrate --entity=App\\Models\\Order
+```
+
+Production apps should prefer generated migrations over runtime auto-migration.
+
+## Real batch insert support
+
+Enable native grouped insert mode:
+
+```env
+AUDIT_BATCH_ENABLED=true
+AUDIT_BATCH_SIZE=500
+```
+
+Then use:
+
+```php
+AuditLogger::batch($logs);
+```
+
+When queueing is disabled, the driver groups audit rows by audit table and inserts chunks through the query builder.
+
+## Multi-tenancy
+
+Enable tenant context:
+
+```env
+AUDIT_TENANT_ENABLED=true
+```
+
+Configure a resolver:
+
+```php
+'tenant' => [
+    'enabled' => true,
+    'resolver' => App\\Audit\\CurrentTenantResolver::class,
+    'columns' => [
+        'type' => 'tenant_type',
+        'id' => 'tenant_id',
+    ],
+],
+```
+
+Your resolver must implement `TenantResolverInterface`.
+
+## Append-only mode
+
+```env
+AUDIT_APPEND_ONLY=true
+```
+
+When enabled, the `EloquentAuditLog` model prevents Eloquent updates and deletes. Pair this with hash-chain mode for stronger audit integrity.
+
+## Relationship auditing helper
+
+Manual relationship audit helpers are available through `RelationshipAuditor`:
+
+```php
+app(RelationshipAuditor::class)->attached($user, 'roles', [$roleId]);
+app(RelationshipAuditor::class)->detached($user, 'roles', [$roleId]);
+app(RelationshipAuditor::class)->synced($user, 'roles', $roleIds);
+```
+
+This keeps relation logging explicit and avoids monkey-patching Laravel relations.
+
+## Authorization
+
+```php
+'authorization' => [
+    'enabled' => true,
+    'view_gate' => 'viewAuditLogs',
+    'restore_gate' => 'restoreFromAudit',
+],
+```
+
+Use `AuditAuthorization` in controllers/admin panels before exposing timeline or restore actions.
+
+## Commands
+
+```bash
+php artisan audit:config-check
+php artisan audit:doctor
+php artisan audit:stats App\\Models\\Order
+php artisan audit:timeline App\\Models\\Order 123
+php artisan audit:diff App\\Models\\Order 456
+php artisan audit:verify App\\Models\\Order
+php artisan audit:partition audit_orders_logs --monthly
+php artisan audit:upgrade v1-to-v2 --dry-run
+```
+
+## Computed changes
+
+Enable stored change sets:
+
+```env
+AUDIT_STORE_CHANGES=true
+```
+
+The package stores field-level changes in the configured `changes` column when the column exists.
+
+## Snapshots
+
+```env
+AUDIT_SNAPSHOTS_ENABLED=true
+AUDIT_SNAPSHOT_EVERY=20
+```
+
+`AuditSnapshotService` can create periodic snapshot rows with action `snapshot`.
+
+## API resources
+
+`AuditLogResource` provides a consistent JSON shape for exposing audit rows through internal APIs.
+
+## Upgrade notes
+
+Run:
+
+```bash
+php artisan audit:upgrade v1-to-v2 --dry-run
+```
+
+The command reports missing v2 columns such as:
+
+- `audit_hash`
+- `previous_hash`
+- `tenant_type`
+- `tenant_id`
+- `changes`
+
+Add columns through normal Laravel migrations before enabling the related features in production.

--- a/docs/v2-major-release.md
+++ b/docs/v2-major-release.md
@@ -1,48 +1,182 @@
 # v2 Major Release Infrastructure
 
-This guide covers the v2 infrastructure added on top of the advanced audit APIs.
+This guide explains the v2 infrastructure layer added on top of the advanced audit APIs. It is written for package users who want production-grade audit tables, high-volume writes, multi-tenant context, secure restore workflows, and operational tooling.
 
-Excluded from this branch by design:
+The v2 work intentionally excludes these items by request:
 
 - Filament plugin
 - Nova / Backpack integrations
 - New external storage drivers such as ClickHouse, OpenSearch, S3, and webhook drivers
 
-## Migration tooling
+## What v2 Adds
 
-Generate a production migration for one audited model:
+v2 turns the package from a model audit logger into a production audit infrastructure package.
 
-```bash
-php artisan audit:make-migration App\\Models\\Order
+| Area | Added support |
+|---|---|
+| Production storage | Migration generation, explicit audit storage creation, upgrade checks |
+| High volume | Native grouped batch inserts when safe |
+| SaaS | Tenant resolver and tenant columns |
+| Compliance | Append-only mode, hash-chain verification, verification failure events |
+| Admin UX | Timeline, diff, stats, API resources, relationship audit helpers |
+| Operations | Doctor, config check, stats, timeline, diff, verify, partition guidance, upgrade commands |
+| Recovery | Safer restore/rollback with authorization and fillable filtering |
+
+## Recommended Production Setup
+
+For production systems, avoid relying only on runtime auto-migration. A safer setup is:
+
+```env
+AUDIT_AUTO_MIGRATION=false
+AUDIT_QUEUE_ENABLED=true
+AUDIT_QUEUE_CONNECTION=redis
+AUDIT_QUEUE_NAME=audit
+AUDIT_APPEND_ONLY=true
+AUDIT_HASH_CHAIN_ENABLED=false
 ```
 
-Create audit storage for configured entities:
+Then generate and run migrations:
+
+```bash
+php artisan audit:make-migration App\Models\Order
+php artisan migrate
+```
+
+Or create storage explicitly for configured entities:
 
 ```bash
 php artisan audit:migrate
-php artisan audit:migrate --entity=App\\Models\\Order
 ```
 
-Production apps should prefer generated migrations over runtime auto-migration.
+Use hash-chain mode only after `audit_hash` and `previous_hash` columns exist.
 
-## Real batch insert support
+## Migration Tooling
 
-Enable native grouped insert mode:
+### Generate an audit table migration
+
+```bash
+php artisan audit:make-migration App\Models\Order
+```
+
+The generated migration includes v2-ready columns:
+
+```text
+id
+entity_id
+action
+old_values
+new_values
+changes
+causer_type
+causer_id
+tenant_type
+tenant_id
+metadata
+created_at
+source
+audit_hash
+previous_hash
+anonymized_at
+```
+
+### Create audit storage directly
+
+```bash
+php artisan audit:migrate
+php artisan audit:migrate --entity=App\Models\Order
+```
+
+`audit:migrate` explicitly creates missing storage. It does not depend on runtime `AUDIT_AUTO_MIGRATION=true`.
+
+### Check upgrade readiness
+
+```bash
+php artisan audit:upgrade v1-to-v2 --dry-run
+```
+
+The command reports missing v2 columns:
+
+```text
+audit_hash
+previous_hash
+tenant_type
+tenant_id
+changes
+```
+
+## Existing Table Migration Example
+
+For a MySQL audit table:
+
+```php
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+Schema::table('audit_orders_logs', function (Blueprint $table): void {
+    $table->json('changes')->nullable()->after('new_values');
+    $table->string('tenant_type')->nullable()->after('causer_id');
+    $table->string('tenant_id')->nullable()->after('tenant_type');
+    $table->string('audit_hash', 128)->nullable()->after('source');
+    $table->string('previous_hash', 128)->nullable()->after('audit_hash');
+
+    $table->index('tenant_id');
+    $table->index(['tenant_id', 'created_at']);
+    $table->index('audit_hash');
+    $table->index('previous_hash');
+});
+```
+
+For PostgreSQL, prefer `jsonb` for `changes`:
+
+```php
+Schema::table('audit_orders_logs', function (Blueprint $table): void {
+    $table->jsonb('changes')->nullable();
+    $table->string('tenant_type')->nullable();
+    $table->string('tenant_id')->nullable();
+    $table->string('audit_hash', 128)->nullable();
+    $table->string('previous_hash', 128)->nullable();
+
+    $table->index('tenant_id');
+    $table->index(['tenant_id', 'created_at']);
+    $table->index('audit_hash');
+    $table->index('previous_hash');
+});
+```
+
+## Batch Inserts
+
+Batch mode is useful for imports, backfills, ETL jobs, and high-volume internal workflows.
+
+Enable it:
 
 ```env
 AUDIT_BATCH_ENABLED=true
 AUDIT_BATCH_SIZE=500
+AUDIT_QUEUE_ENABLED=false
 ```
 
-Then use:
+Use it:
 
 ```php
-AuditLogger::batch($logs);
+use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
+
+AuditLogger::batch([
+    AuditLog::fromArray([
+        'entity_type' => App\Models\Order::class,
+        'entity_id' => 1,
+        'action' => 'imported',
+        'old_values' => null,
+        'new_values' => ['status' => 'paid'],
+        'metadata' => ['source' => 'legacy_import'],
+        'created_at' => now(),
+    ]),
+]);
 ```
 
-When queueing is disabled, the driver groups audit rows by audit table and inserts chunks through the query builder.
+Native batch mode is intentionally disabled when hash-chain mode is enabled. Hash chains must be generated sequentially row by row.
 
-## Multi-tenancy
+## Multi-Tenancy
 
 Enable tenant context:
 
@@ -50,12 +184,37 @@ Enable tenant context:
 AUDIT_TENANT_ENABLED=true
 ```
 
-Configure a resolver:
+Create a resolver:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Audit;
+
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
+
+final class CurrentTenantResolver implements TenantResolverInterface
+{
+    public function resolve(): array
+    {
+        $tenant = tenant();
+
+        return [
+            'type' => $tenant?->getMorphClass(),
+            'id' => $tenant?->getKey(),
+        ];
+    }
+}
+```
+
+Configure it:
 
 ```php
 'tenant' => [
     'enabled' => true,
-    'resolver' => App\\Audit\\CurrentTenantResolver::class,
+    'resolver' => App\Audit\CurrentTenantResolver::class,
     'columns' => [
         'type' => 'tenant_type',
         'id' => 'tenant_id',
@@ -63,90 +222,326 @@ Configure a resolver:
 ],
 ```
 
-Your resolver must implement `TenantResolverInterface`.
+Query tenant-specific logs:
 
-## Append-only mode
+```php
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+
+$logs = EloquentAuditLog::forEntity(App\Models\Order::class)
+    ->forTenant($tenant->id, $tenant::class)
+    ->latest()
+    ->paginate();
+```
+
+## Append-Only Mode
+
+Enable append-only protection:
 
 ```env
 AUDIT_APPEND_ONLY=true
 ```
 
-When enabled, the `EloquentAuditLog` model prevents Eloquent updates and deletes. Pair this with hash-chain mode for stronger audit integrity.
+When enabled, `EloquentAuditLog` prevents Eloquent updates and deletes. This protects application-level writes. Database administrators can still modify rows directly, so combine this with hash-chain verification for stronger tamper detection.
 
-## Relationship auditing helper
+## Hash-Chain Verification
 
-Manual relationship audit helpers are available through `RelationshipAuditor`:
+Hash-chain mode remains disabled by default.
+
+```env
+AUDIT_HASH_CHAIN_ENABLED=true
+AUDIT_HASH_ALGORITHM=sha256
+AUDIT_HASH_KEY=your-private-audit-key
+```
+
+Each row stores:
+
+- `previous_hash`: hash from the previous audit row in the same audit table;
+- `audit_hash`: HMAC of the canonical audit payload plus `previous_hash`.
+
+Verify through code:
 
 ```php
+$result = AuditLogger::verifyHashChain(App\Models\Order::class);
+
+if (! $result['valid']) {
+    report($result['failures']);
+}
+```
+
+Verify through Artisan:
+
+```bash
+php artisan audit:verify App\Models\Order
+php artisan audit:verify App\Models\Order --entity-id=123
+php artisan audit:verify App\Models\Order --fail-on-missing-hash
+```
+
+When verification fails, the package dispatches `AuditVerificationFailed`.
+
+## Relationship Auditing
+
+Relationship auditing is explicit. The package does not monkey-patch Eloquent relation methods.
+
+```php
+use iamfarhad\LaravelAuditLog\Services\RelationshipAuditor;
+
 app(RelationshipAuditor::class)->attached($user, 'roles', [$roleId]);
 app(RelationshipAuditor::class)->detached($user, 'roles', [$roleId]);
 app(RelationshipAuditor::class)->synced($user, 'roles', $roleIds);
 ```
 
-This keeps relation logging explicit and avoids monkey-patching Laravel relations.
+This writes actions like:
 
-## Authorization
+```text
+roles_attached
+roles_detached
+roles_synced
+```
+
+You can add metadata:
 
 ```php
-'authorization' => [
-    'enabled' => true,
-    'view_gate' => 'viewAuditLogs',
-    'restore_gate' => 'restoreFromAudit',
-],
+app(RelationshipAuditor::class)->attached(
+    $user,
+    'roles',
+    [$roleId],
+    ['reason' => 'admin_grant']
+);
 ```
 
-Use `AuditAuthorization` in controllers/admin panels before exposing timeline or restore actions.
+## Restore and Rollback Safety
 
-## Commands
+Enable authorization:
 
-```bash
-php artisan audit:config-check
-php artisan audit:doctor
-php artisan audit:stats App\\Models\\Order
-php artisan audit:timeline App\\Models\\Order 123
-php artisan audit:diff App\\Models\\Order 456
-php artisan audit:verify App\\Models\\Order
-php artisan audit:partition audit_orders_logs --monthly
-php artisan audit:upgrade v1-to-v2 --dry-run
+```env
+AUDIT_AUTHORIZATION_ENABLED=true
 ```
 
-## Computed changes
+Configure gates:
 
-Enable stored change sets:
+```php
+Gate::define('viewAuditLogs', fn ($user, $model) => $user->can('view', $model));
+Gate::define('restoreFromAudit', fn ($user, $model) => $user->can('update', $model));
+```
+
+Configure restore behavior:
+
+```env
+AUDIT_RESTORE_VALIDATE_FILLABLE=true
+AUDIT_RESTORE_AUDIT=true
+```
+
+Options:
+
+- `AUDIT_RESTORE_VALIDATE_FILLABLE=true`: only apply fields from the model's `$fillable` array.
+- `AUDIT_RESTORE_AUDIT=false`: save restored models without creating a new audit row.
+
+Usage:
+
+```php
+$order->restoreFromAudit($auditLogId);
+$order->rollbackToAudit($auditLogId);
+$preview = $order->previewRestore($auditLogId, 'rollback');
+```
+
+## Computed Change Sets
+
+Enable stored field-level changes:
 
 ```env
 AUDIT_STORE_CHANGES=true
 ```
 
-The package stores field-level changes in the configured `changes` column when the column exists.
+The package writes a `changes` array when the column exists:
+
+```php
+[
+    [
+        'field' => 'status',
+        'old' => 'pending',
+        'new' => 'approved',
+        'type' => 'string',
+        'label' => 'Status',
+    ],
+]
+```
+
+This makes dashboards and APIs faster because they do not need to recompute diffs repeatedly.
 
 ## Snapshots
+
+Snapshots periodically capture the full model state.
 
 ```env
 AUDIT_SNAPSHOTS_ENABLED=true
 AUDIT_SNAPSHOT_EVERY=20
 ```
 
-`AuditSnapshotService` can create periodic snapshot rows with action `snapshot`.
+Manual snapshot:
 
-## API resources
-
-`AuditLogResource` provides a consistent JSON shape for exposing audit rows through internal APIs.
-
-## Upgrade notes
-
-Run:
-
-```bash
-php artisan audit:upgrade v1-to-v2 --dry-run
+```php
+app(\iamfarhad\LaravelAuditLog\Services\AuditSnapshotService::class)->snapshot($order);
 ```
 
-The command reports missing v2 columns such as:
+Automatic helper:
 
-- `audit_hash`
-- `previous_hash`
-- `tenant_type`
-- `tenant_id`
-- `changes`
+```php
+app(\iamfarhad\LaravelAuditLog\Services\AuditSnapshotService::class)->maybeSnapshot($order);
+```
 
-Add columns through normal Laravel migrations before enabling the related features in production.
+Snapshot rows use the action `snapshot` and store the model attributes in `new_values`.
+
+## API Resources
+
+Use package resources in your own controllers:
+
+```php
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditLogResource;
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditTimelineResource;
+use iamfarhad\LaravelAuditLog\Http\Resources\AuditDiffResource;
+
+return AuditLogResource::collection(
+    AuditLogger::query(App\Models\Order::class)->latest()->paginate()
+);
+```
+
+Timeline:
+
+```php
+return AuditTimelineResource::collection($order->auditTimeline());
+```
+
+Diff:
+
+```php
+return AuditDiffResource::collection($order->auditDiff($auditLogId));
+```
+
+## Operational Commands
+
+| Command | Description |
+|---|---|
+| `audit:make-migration App\Models\Order` | Generate an audit table migration |
+| `audit:migrate` | Create audit storage for configured entities |
+| `audit:migrate --entity=App\Models\Order` | Create storage for one entity |
+| `audit:config-check` | Validate config, resolver, transformers, and hash settings |
+| `audit:doctor` | Check entity config and audit table existence |
+| `audit:stats App\Models\Order` | Show audit summary statistics |
+| `audit:timeline App\Models\Order 123` | Show timeline for one entity id |
+| `audit:diff App\Models\Order 456` | Show field changes for one audit row |
+| `audit:verify App\Models\Order` | Verify hash-chain integrity |
+| `audit:partition audit_orders_logs --monthly` | Show safe partitioning guidance |
+| `audit:upgrade v1-to-v2 --dry-run` | Report missing v2 columns |
+| `audit:cleanup --dry-run` | Preview retention cleanup |
+
+## Partitioning Guidance
+
+`audit:partition` is guidance-only. It does not run DDL because partitioning is database- and workload-specific.
+
+For large tables:
+
+- PostgreSQL: consider range partitioning by `created_at`.
+- MySQL: consider RANGE partitioning on a generated date key or `TO_DAYS(created_at)`.
+- Keep indexes aligned with common queries: `entity_id`, `tenant_id`, `created_at`, `action`.
+
+## Events
+
+Available events:
+
+```php
+use iamfarhad\LaravelAuditLog\Events\AuditCreating;
+use iamfarhad\LaravelAuditLog\Events\AuditCreated;
+use iamfarhad\LaravelAuditLog\Events\AuditVerificationFailed;
+```
+
+Example listener:
+
+```php
+Event::listen(AuditVerificationFailed::class, function (AuditVerificationFailed $event): void {
+    report([
+        'entity' => $event->entityClass,
+        'failures' => $event->failures,
+    ]);
+});
+```
+
+## Presets
+
+The config includes a `preset` value for future package-level defaults:
+
+```env
+AUDIT_PRESET=basic
+```
+
+Recommended semantic presets for downstream apps:
+
+| Preset | Suggested behavior |
+|---|---|
+| `basic` | default auditing with safe exclusions |
+| `compliance` | append-only, hash-chain-ready, redaction-heavy |
+| `high_performance` | queueing, batch where safe, larger chunk sizes |
+| `saas` | tenant resolver, tenant indexes, stricter authorization |
+
+## Production Checklist
+
+Before enabling v2 features in production:
+
+- [ ] Publish config.
+- [ ] Generate audit migrations.
+- [ ] Add nullable v2 columns to existing audit tables.
+- [ ] Run `audit:upgrade v1-to-v2 --dry-run`.
+- [ ] Run `audit:config-check`.
+- [ ] Run `audit:doctor`.
+- [ ] Decide whether runtime auto-migration should be disabled.
+- [ ] Configure queue workers if queueing is enabled.
+- [ ] Configure gates if audit authorization is enabled.
+- [ ] Enable hash-chain mode only after hash columns exist.
+- [ ] Verify restore workflows in staging.
+- [ ] Add monitoring for `AuditVerificationFailed`.
+
+## Troubleshooting
+
+### `audit:verify` says hash columns are missing
+
+Add nullable `audit_hash` and `previous_hash` columns before verifying or enabling hash-chain mode.
+
+### Batch inserts are slower than expected
+
+Native batch mode is skipped when queueing or hash-chain mode is enabled. This is intentional.
+
+### Tenant columns remain null
+
+Check that:
+
+- `AUDIT_TENANT_ENABLED=true`;
+- resolver implements `TenantResolverInterface`;
+- audit tables have `tenant_type` and `tenant_id` columns;
+- the resolver returns a non-null tenant in the current execution context.
+
+### Restore applies too many fields
+
+Set:
+
+```env
+AUDIT_RESTORE_VALIDATE_FILLABLE=true
+```
+
+Then review the model's `$fillable` array.
+
+### Audit rows can still be edited in the database
+
+Append-only mode blocks Eloquent updates/deletes. It does not prevent direct database changes. Use database permissions and hash-chain verification for stronger protection.
+
+## Upgrade Order
+
+Recommended order from v1/advanced branch to v2:
+
+1. Merge the advanced audit API work.
+2. Deploy v2 code with new features disabled.
+3. Run `audit:upgrade v1-to-v2 --dry-run`.
+4. Add nullable v2 columns to existing audit tables.
+5. Enable tenancy/change/snapshot features one at a time.
+6. Enable append-only mode.
+7. Enable hash-chain mode only after verifying hash columns exist.
+8. Run `audit:doctor`, `audit:config-check`, and `audit:verify`.
+9. Monitor queue workers and verification events.

--- a/src/AuditLoggerServiceProvider.php
+++ b/src/AuditLoggerServiceProvider.php
@@ -4,22 +4,40 @@ declare(strict_types=1);
 
 namespace iamfarhad\LaravelAuditLog;
 
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditConfigCheckCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditDiffCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditDoctorCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditPartitionCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditStatsCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditTimelineCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditUpgradeCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditVerifyCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\CleanupAuditLogsCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\MakeAuditMigrationCommand;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
 use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\RetentionServiceInterface;
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
 use iamfarhad\LaravelAuditLog\Drivers\MySQLDriver;
 use iamfarhad\LaravelAuditLog\Drivers\PostgreSQLDriver;
 use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
 use iamfarhad\LaravelAuditLog\Services\AuditAnalytics;
+use iamfarhad\LaravelAuditLog\Services\AuditAuthorization;
+use iamfarhad\LaravelAuditLog\Services\AuditChangeSet;
+use iamfarhad\LaravelAuditLog\Services\AuditConfigValidator;
 use iamfarhad\LaravelAuditLog\Services\AuditFieldTransformer;
 use iamfarhad\LaravelAuditLog\Services\AuditHash;
 use iamfarhad\LaravelAuditLog\Services\AuditHashVerifier;
 use iamfarhad\LaravelAuditLog\Services\AuditLogger;
+use iamfarhad\LaravelAuditLog\Services\AuditMigrationGenerator;
 use iamfarhad\LaravelAuditLog\Services\AuditRestorer;
+use iamfarhad\LaravelAuditLog\Services\AuditSnapshotService;
+use iamfarhad\LaravelAuditLog\Services\AuditTableNameResolver;
 use iamfarhad\LaravelAuditLog\Services\AuditTimeline;
 use iamfarhad\LaravelAuditLog\Services\CauserResolver;
+use iamfarhad\LaravelAuditLog\Services\RelationshipAuditor;
 use iamfarhad\LaravelAuditLog\Services\RetentionService;
+use iamfarhad\LaravelAuditLog\Services\TenantResolver;
 use Illuminate\Support\ServiceProvider;
 
 final class AuditLoggerServiceProvider extends ServiceProvider
@@ -40,6 +58,12 @@ final class AuditLoggerServiceProvider extends ServiceProvider
                 )
         );
 
+        $this->app->singleton(TenantResolverInterface::class, function ($app) {
+            $resolver = $app['config']['audit-logger.tenant']['resolver'] ?? TenantResolver::class;
+
+            return $resolver === TenantResolver::class ? new TenantResolver : $app->make($resolver);
+        });
+
         $this->app->singleton(AuditLogger::class, function ($app) {
             $driverName = $app['config']['audit-logger.default'] ?? 'mysql';
             $connection = $app['config']["audit-logger.drivers.{$driverName}.connection"] ?? config('database.default');
@@ -54,12 +78,19 @@ final class AuditLoggerServiceProvider extends ServiceProvider
         });
 
         $this->app->alias(AuditLogger::class, 'audit-logger');
+        $this->app->singleton(AuditAnalytics::class);
+        $this->app->singleton(AuditAuthorization::class);
+        $this->app->singleton(AuditChangeSet::class);
+        $this->app->singleton(AuditConfigValidator::class);
         $this->app->singleton(AuditFieldTransformer::class);
         $this->app->singleton(AuditHash::class);
         $this->app->singleton(AuditHashVerifier::class);
-        $this->app->singleton(AuditAnalytics::class);
-        $this->app->singleton(AuditTimeline::class);
+        $this->app->singleton(AuditMigrationGenerator::class);
         $this->app->singleton(AuditRestorer::class);
+        $this->app->singleton(AuditSnapshotService::class);
+        $this->app->singleton(AuditTableNameResolver::class);
+        $this->app->singleton(AuditTimeline::class);
+        $this->app->singleton(RelationshipAuditor::class);
         $this->app->singleton(RetentionServiceInterface::class, RetentionService::class);
     }
 
@@ -71,7 +102,16 @@ final class AuditLoggerServiceProvider extends ServiceProvider
             ], 'audit-logger-config');
 
             $this->commands([
+                AuditConfigCheckCommand::class,
+                AuditDiffCommand::class,
+                AuditDoctorCommand::class,
+                AuditPartitionCommand::class,
+                AuditStatsCommand::class,
+                AuditTimelineCommand::class,
+                AuditUpgradeCommand::class,
+                AuditVerifyCommand::class,
                 CleanupAuditLogsCommand::class,
+                MakeAuditMigrationCommand::class,
             ]);
         }
     }

--- a/src/AuditLoggerServiceProvider.php
+++ b/src/AuditLoggerServiceProvider.php
@@ -7,6 +7,7 @@ namespace iamfarhad\LaravelAuditLog;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditConfigCheckCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditDiffCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditDoctorCommand;
+use iamfarhad\LaravelAuditLog\Console\Commands\AuditMigrateCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditPartitionCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditStatsCommand;
 use iamfarhad\LaravelAuditLog\Console\Commands\AuditTimelineCommand;
@@ -105,6 +106,7 @@ final class AuditLoggerServiceProvider extends ServiceProvider
                 AuditConfigCheckCommand::class,
                 AuditDiffCommand::class,
                 AuditDoctorCommand::class,
+                AuditMigrateCommand::class,
                 AuditPartitionCommand::class,
                 AuditStatsCommand::class,
                 AuditTimelineCommand::class,

--- a/src/Console/Commands/AuditConfigCheckCommand.php
+++ b/src/Console/Commands/AuditConfigCheckCommand.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Services\AuditConfigValidator;
+use Illuminate\Console\Command;
+
+final class AuditConfigCheckCommand extends Command
+{
+    protected $signature = 'audit:config-check';
+
+    protected $description = 'Validate audit logger configuration';
+
+    public function handle(AuditConfigValidator $validator): int
+    {
+        $result = $validator->validate();
+
+        foreach ($result['warnings'] as $warning) {
+            $this->warn($warning);
+        }
+
+        foreach ($result['errors'] as $error) {
+            $this->error($error);
+        }
+
+        if ($result['errors'] !== []) {
+            return self::FAILURE;
+        }
+
+        $this->info('Audit configuration is valid.');
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditDiffCommand.php
+++ b/src/Console/Commands/AuditDiffCommand.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditTimeline;
+use Illuminate\Console\Command;
+
+final class AuditDiffCommand extends Command
+{
+    protected $signature = 'audit:diff {entity : Audited model class} {auditId : Audit log id}';
+
+    protected $description = 'Show field-level changes for an audit log';
+
+    public function handle(AuditTimeline $timeline): int
+    {
+        $entity = (string) $this->argument('entity');
+        $auditId = (string) $this->argument('auditId');
+
+        $log = EloquentAuditLog::forEntity($entity)->newQuery()->whereKey($auditId)->first();
+
+        if (! $log instanceof EloquentAuditLog) {
+            $this->error('Audit log not found.');
+
+            return self::FAILURE;
+        }
+
+        $changes = $timeline->diff($log);
+
+        if ($changes === []) {
+            $this->info('No field changes found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['Field', 'Old', 'New'], array_map(fn (array $change): array => [
+            $change['field'],
+            is_scalar($change['old']) || $change['old'] === null ? (string) $change['old'] : json_encode($change['old']),
+            is_scalar($change['new']) || $change['new'] === null ? (string) $change['new'] : json_encode($change['new']),
+        ], $changes));
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditDoctorCommand.php
+++ b/src/Console/Commands/AuditDoctorCommand.php
@@ -41,10 +41,17 @@ final class AuditDoctorCommand extends Command
             }
 
             $table = $tables->resolve($entityClass);
-            $exists = Schema::connection(config('database.default'))->hasTable($table);
+            $exists = Schema::connection($this->auditConnection())->hasTable($table);
             $exists ? $this->info("OK: {$table} exists for {$entityClass}") : $this->warn("Missing audit table [{$table}] for {$entityClass}");
         }
 
         return $failed ? self::FAILURE : self::SUCCESS;
+    }
+
+    private function auditConnection(): string
+    {
+        $driver = (string) config('audit-logger.default', 'mysql');
+
+        return (string) config("audit-logger.drivers.{$driver}.connection", config('database.default'));
     }
 }

--- a/src/Console/Commands/AuditDoctorCommand.php
+++ b/src/Console/Commands/AuditDoctorCommand.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Services\AuditConfigValidator;
+use iamfarhad\LaravelAuditLog\Services\AuditTableNameResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+
+final class AuditDoctorCommand extends Command
+{
+    protected $signature = 'audit:doctor {--entity= : Check one audited entity class}';
+
+    protected $description = 'Run audit logger health checks';
+
+    public function handle(AuditConfigValidator $validator, AuditTableNameResolver $tables): int
+    {
+        $result = $validator->validate();
+        $failed = false;
+
+        foreach ($result['warnings'] as $warning) {
+            $this->warn($warning);
+        }
+
+        foreach ($result['errors'] as $error) {
+            $this->error($error);
+            $failed = true;
+        }
+
+        $entities = $this->option('entity')
+            ? [(string) $this->option('entity') => []]
+            : (array) config('audit-logger.entities', []);
+
+        foreach (array_keys($entities) as $entityClass) {
+            if (! class_exists($entityClass)) {
+                $this->error("Configured entity [{$entityClass}] does not exist.");
+                $failed = true;
+                continue;
+            }
+
+            $table = $tables->resolve($entityClass);
+            $exists = Schema::connection(config('database.default'))->hasTable($table);
+            $exists ? $this->info("OK: {$table} exists for {$entityClass}") : $this->warn("Missing audit table [{$table}] for {$entityClass}");
+        }
+
+        return $failed ? self::FAILURE : self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditMigrateCommand.php
+++ b/src/Console/Commands/AuditMigrateCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Drivers\MySQLDriver;
+use iamfarhad\LaravelAuditLog\Drivers\PostgreSQLDriver;
+use Illuminate\Console\Command;
+
+final class AuditMigrateCommand extends Command
+{
+    protected $signature = 'audit:migrate {--entity= : Only create storage for one audited entity class}';
+
+    protected $description = 'Create audit storage for configured audited entities';
+
+    public function handle(): int
+    {
+        $entities = $this->option('entity')
+            ? [(string) $this->option('entity')]
+            : array_keys((array) config('audit-logger.entities', []));
+
+        if ($entities === []) {
+            $this->warn('No audited entities configured.');
+
+            return self::SUCCESS;
+        }
+
+        $driver = $this->driver();
+
+        foreach ($entities as $entityClass) {
+            if (! class_exists($entityClass)) {
+                $this->error("Entity class [{$entityClass}] does not exist.");
+
+                return self::FAILURE;
+            }
+
+            $driver->ensureStorageExists($entityClass);
+            $this->info("Audit storage is ready for {$entityClass}.");
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function driver(): MySQLDriver|PostgreSQLDriver
+    {
+        $driver = (string) config('audit-logger.default', 'mysql');
+        $connection = config("audit-logger.drivers.{$driver}.connection", config('database.default'));
+
+        return match ($driver) {
+            'mysql' => new MySQLDriver($connection),
+            'postgresql', 'pgsql' => new PostgreSQLDriver($connection),
+            default => throw new \InvalidArgumentException("Unsupported audit driver [{$driver}]."),
+        };
+    }
+}

--- a/src/Console/Commands/AuditMigrateCommand.php
+++ b/src/Console/Commands/AuditMigrateCommand.php
@@ -35,8 +35,13 @@ final class AuditMigrateCommand extends Command
                 return self::FAILURE;
             }
 
-            $driver->ensureStorageExists($entityClass);
-            $this->info("Audit storage is ready for {$entityClass}.");
+            if ($driver->storageExistsForEntity($entityClass)) {
+                $this->info("Audit storage already exists for {$entityClass}.");
+                continue;
+            }
+
+            $driver->createStorageForEntity($entityClass);
+            $this->info("Created audit storage for {$entityClass}.");
         }
 
         return self::SUCCESS;

--- a/src/Console/Commands/AuditPartitionCommand.php
+++ b/src/Console/Commands/AuditPartitionCommand.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use Illuminate\Console\Command;
+
+final class AuditPartitionCommand extends Command
+{
+    protected $signature = 'audit:partition {table : Audit table name} {--monthly : Show monthly partition guidance}';
+
+    protected $description = 'Show database partitioning guidance for large audit tables';
+
+    public function handle(): int
+    {
+        $table = (string) $this->argument('table');
+
+        $this->info("Partitioning guidance for [{$table}]");
+        $this->line('Use native database partitioning for production tables with very large audit volume.');
+        $this->line('PostgreSQL: create range partitions by created_at.');
+        $this->line('MySQL: use RANGE partitioning on a generated date key or TO_DAYS(created_at).');
+
+        if ($this->option('monthly')) {
+            $month = now()->format('Y_m');
+            $this->newLine();
+            $this->line("Example partition name: {$table}_{$month}");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditStatsCommand.php
+++ b/src/Console/Commands/AuditStatsCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
+use Illuminate\Console\Command;
+
+final class AuditStatsCommand extends Command
+{
+    protected $signature = 'audit:stats {entity : Audited model class}';
+
+    protected $description = 'Show audit log statistics for an entity';
+
+    public function handle(): int
+    {
+        $entity = (string) $this->argument('entity');
+        $summary = AuditLogger::analytics()->summary($entity);
+
+        $this->info("Total: {$summary['total']}");
+        $this->line('First audit: '.($summary['first_audit_at'] ?? 'n/a'));
+        $this->line('Last audit: '.($summary['last_audit_at'] ?? 'n/a'));
+
+        foreach ($summary['actions'] as $action => $count) {
+            $this->line("{$action}: {$count}");
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditTimelineCommand.php
+++ b/src/Console/Commands/AuditTimelineCommand.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Console\Command;
+
+final class AuditTimelineCommand extends Command
+{
+    protected $signature = 'audit:timeline {entity : Audited model class} {entityId : Entity id}';
+
+    protected $description = 'Show an audit timeline for an entity instance';
+
+    public function handle(): int
+    {
+        $entity = (string) $this->argument('entity');
+        $entityId = (string) $this->argument('entityId');
+
+        $logs = EloquentAuditLog::forEntity($entity)
+            ->newQuery()
+            ->where('entity_id', $entityId)
+            ->orderBy('created_at')
+            ->orderBy('id')
+            ->get(['id', 'action', 'causer_type', 'causer_id', 'source', 'created_at']);
+
+        if ($logs->isEmpty()) {
+            $this->warn('No audit logs found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->table(['ID', 'Action', 'Causer', 'Source', 'Created At'], $logs->map(fn ($log): array => [
+            $log->getKey(),
+            $log->action,
+            trim(($log->causer_type ?? '').'#'.($log->causer_id ?? ''), '#'),
+            $log->source,
+            (string) $log->created_at,
+        ])->all());
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditUpgradeCommand.php
+++ b/src/Console/Commands/AuditUpgradeCommand.php
@@ -24,11 +24,12 @@ final class AuditUpgradeCommand extends Command
 
         $dryRun = (bool) $this->option('dry-run');
         $entities = array_keys((array) config('audit-logger.entities', []));
+        $schema = Schema::connection($this->auditConnection());
 
         foreach ($entities as $entityClass) {
             $tableName = $tables->resolve($entityClass);
 
-            if (! Schema::hasTable($tableName)) {
+            if (! $schema->hasTable($tableName)) {
                 $this->warn("Missing audit table [{$tableName}].");
                 continue;
             }
@@ -39,7 +40,7 @@ final class AuditUpgradeCommand extends Command
                 'tenant_type',
                 'tenant_id',
                 'changes',
-            ], fn (string $column): bool => ! Schema::hasColumn($tableName, $column)));
+            ], fn (string $column): bool => ! $schema->hasColumn($tableName, $column)));
 
             if ($missing === []) {
                 $this->info("{$tableName}: already v2-ready.");
@@ -54,5 +55,12 @@ final class AuditUpgradeCommand extends Command
         }
 
         return self::SUCCESS;
+    }
+
+    private function auditConnection(): string
+    {
+        $driver = (string) config('audit-logger.default', 'mysql');
+
+        return (string) config("audit-logger.drivers.{$driver}.connection", config('database.default'));
     }
 }

--- a/src/Console/Commands/AuditUpgradeCommand.php
+++ b/src/Console/Commands/AuditUpgradeCommand.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Services\AuditTableNameResolver;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
+
+final class AuditUpgradeCommand extends Command
+{
+    protected $signature = 'audit:upgrade {target=v1-to-v2} {--dry-run : Show required changes without applying them}';
+
+    protected $description = 'Check or apply audit logger upgrade steps';
+
+    public function handle(AuditTableNameResolver $tables): int
+    {
+        if ($this->argument('target') !== 'v1-to-v2') {
+            $this->error('Only v1-to-v2 upgrade checks are supported.');
+
+            return self::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $entities = array_keys((array) config('audit-logger.entities', []));
+
+        foreach ($entities as $entityClass) {
+            $tableName = $tables->resolve($entityClass);
+
+            if (! Schema::hasTable($tableName)) {
+                $this->warn("Missing audit table [{$tableName}].");
+                continue;
+            }
+
+            $missing = array_values(array_filter([
+                'audit_hash',
+                'previous_hash',
+                'tenant_type',
+                'tenant_id',
+                'changes',
+            ], fn (string $column): bool => ! Schema::hasColumn($tableName, $column)));
+
+            if ($missing === []) {
+                $this->info("{$tableName}: already v2-ready.");
+                continue;
+            }
+
+            $this->line("{$tableName}: missing ".implode(', ', $missing));
+        }
+
+        if ($dryRun) {
+            $this->info('Dry run complete. Generate migrations with audit:make-migration or add missing columns manually.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Console/Commands/AuditVerifyCommand.php
+++ b/src/Console/Commands/AuditVerifyCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Facades\AuditLogger;
+use Illuminate\Console\Command;
+
+final class AuditVerifyCommand extends Command
+{
+    protected $signature = 'audit:verify {entity : Audited model class} {--entity-id= : Limit verification to one entity id} {--fail-on-missing-hash : Return failure for missing hash columns}';
+
+    protected $description = 'Verify tamper-evident audit hash chains';
+
+    public function handle(): int
+    {
+        $result = AuditLogger::verifyHashChain((string) $this->argument('entity'), $this->option('entity-id'));
+
+        $this->line('Checked: '.$result['checked']);
+
+        if ($result['valid']) {
+            $this->info('Audit hash chain is valid.');
+
+            return self::SUCCESS;
+        }
+
+        foreach ($result['failures'] as $failure) {
+            $this->error(($failure['code'] ?? 'hash_failure').': '.($failure['message'] ?? 'Audit verification failed.'));
+        }
+
+        if (! $this->option('fail-on-missing-hash')) {
+            $codes = array_column($result['failures'], 'code');
+            if (in_array('missing_hash_columns', $codes, true)) {
+                return self::SUCCESS;
+            }
+        }
+
+        return self::FAILURE;
+    }
+}

--- a/src/Console/Commands/MakeAuditMigrationCommand.php
+++ b/src/Console/Commands/MakeAuditMigrationCommand.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Console\Commands;
+
+use iamfarhad\LaravelAuditLog\Services\AuditMigrationGenerator;
+use Illuminate\Console\Command;
+
+final class MakeAuditMigrationCommand extends Command
+{
+    protected $signature = 'audit:make-migration {entity : Audited model class}';
+
+    protected $description = 'Create a production-ready migration for an audit table';
+
+    public function handle(AuditMigrationGenerator $generator): int
+    {
+        $entity = (string) $this->argument('entity');
+
+        if (! class_exists($entity)) {
+            $this->error("Entity class [{$entity}] does not exist.");
+
+            return self::FAILURE;
+        }
+
+        $path = $generator->create($entity);
+        $this->info("Created audit migration: {$path}");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Contracts/TenantResolverInterface.php
+++ b/src/Contracts/TenantResolverInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Contracts;
+
+interface TenantResolverInterface
+{
+    /**
+     * @return array{type: class-string|string|null, id: string|int|null}
+     */
+    public function resolve(): array;
+}

--- a/src/Drivers/MySQLDriver.php
+++ b/src/Drivers/MySQLDriver.php
@@ -6,7 +6,9 @@ namespace iamfarhad\LaravelAuditLog\Drivers;
 
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditChangeSet;
 use iamfarhad\LaravelAuditLog\Services\AuditHash;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -56,8 +58,18 @@ final class MySQLDriver implements AuditDriverInterface
     /** @param array<AuditLogInterface> $logs */
     public function storeBatch(array $logs): void
     {
+        $grouped = [];
+
         foreach ($logs as $log) {
-            $this->store($log);
+            $this->validateEntityType($log->getEntityType());
+            $this->ensureStorageExists($log->getEntityType());
+            $grouped[$this->getTableName($log->getEntityType())][] = $this->payloadForInsert($log);
+        }
+
+        foreach ($grouped as $tableName => $rows) {
+            foreach (array_chunk($rows, (int) config('audit-logger.batch.size', 500)) as $chunk) {
+                DB::connection($this->connection)->table($tableName)->insert($chunk);
+            }
         }
     }
 
@@ -71,8 +83,11 @@ final class MySQLDriver implements AuditDriverInterface
             $table->string('action');
             $table->json('old_values')->nullable();
             $table->json('new_values')->nullable();
+            $table->json('changes')->nullable();
             $table->string('causer_type')->nullable();
             $table->string('causer_id')->nullable();
+            $table->string('tenant_type')->nullable();
+            $table->string('tenant_id')->nullable();
             $table->json('metadata')->nullable();
             $table->timestamp('created_at');
             $table->string('source')->nullable();
@@ -81,6 +96,7 @@ final class MySQLDriver implements AuditDriverInterface
             $table->timestamp('anonymized_at')->nullable();
             $table->index('entity_id');
             $table->index('causer_id');
+            $table->index('tenant_id');
             $table->index('created_at');
             $table->index('action');
             $table->index('source');
@@ -89,6 +105,7 @@ final class MySQLDriver implements AuditDriverInterface
             $table->index('anonymized_at');
             $table->index(['entity_id', 'action']);
             $table->index(['entity_id', 'created_at']);
+            $table->index(['tenant_id', 'created_at']);
             $table->index(['causer_id', 'action']);
             $table->index(['action', 'created_at']);
         });
@@ -138,11 +155,48 @@ final class MySQLDriver implements AuditDriverInterface
             'created_at' => $log->getCreatedAt(),
             'source' => $log->getSource(),
         ];
+
+        $payload = $this->withV2Context($log, $payload);
+
         $hash = app(AuditHash::class);
         if ($hash->enabled()) {
             $previousHash = $this->latestHashForEntity($log->getEntityType());
             $payload['previous_hash'] = $previousHash;
             $payload['audit_hash'] = $hash->compute($log, $previousHash);
+        }
+
+        return $this->filterPayloadForTable($this->getTableName($log->getEntityType()), $payload);
+    }
+
+    private function payloadForInsert(AuditLogInterface $log): array
+    {
+        return array_map(
+            fn (mixed $value): mixed => is_array($value) ? json_encode($value, JSON_THROW_ON_ERROR) : $value,
+            $this->payloadForLog($log)
+        );
+    }
+
+    private function withV2Context(AuditLogInterface $log, array $payload): array
+    {
+        if ((bool) config('audit-logger.tenant.enabled', false)) {
+            $tenant = app(TenantResolverInterface::class)->resolve();
+            $payload[config('audit-logger.tenant.columns.type', 'tenant_type')] = $tenant['type'];
+            $payload[config('audit-logger.tenant.columns.id', 'tenant_id')] = $tenant['id'];
+        }
+
+        if ((bool) config('audit-logger.changes.store', false)) {
+            $payload[(string) config('audit-logger.changes.column', 'changes')] = app(AuditChangeSet::class)->make($log->getOldValues(), $log->getNewValues());
+        }
+
+        return $payload;
+    }
+
+    private function filterPayloadForTable(string $tableName, array $payload): array
+    {
+        foreach (array_keys($payload) as $column) {
+            if (! Schema::connection($this->connection)->hasColumn($tableName, $column)) {
+                unset($payload[$column]);
+            }
         }
 
         return $payload;

--- a/src/Drivers/PostgreSQLDriver.php
+++ b/src/Drivers/PostgreSQLDriver.php
@@ -6,7 +6,9 @@ namespace iamfarhad\LaravelAuditLog\Drivers;
 
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use iamfarhad\LaravelAuditLog\Services\AuditChangeSet;
 use iamfarhad\LaravelAuditLog\Services\AuditHash;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -56,8 +58,18 @@ final class PostgreSQLDriver implements AuditDriverInterface
     /** @param array<AuditLogInterface> $logs */
     public function storeBatch(array $logs): void
     {
+        $grouped = [];
+
         foreach ($logs as $log) {
-            $this->store($log);
+            $this->validateEntityType($log->getEntityType());
+            $this->ensureStorageExists($log->getEntityType());
+            $grouped[$this->getTableName($log->getEntityType())][] = $this->payloadForInsert($log);
+        }
+
+        foreach ($grouped as $tableName => $rows) {
+            foreach (array_chunk($rows, (int) config('audit-logger.batch.size', 500)) as $chunk) {
+                DB::connection($this->connection)->table($tableName)->insert($chunk);
+            }
         }
     }
 
@@ -71,8 +83,11 @@ final class PostgreSQLDriver implements AuditDriverInterface
             $table->string('action');
             $table->jsonb('old_values')->nullable();
             $table->jsonb('new_values')->nullable();
+            $table->jsonb('changes')->nullable();
             $table->string('causer_type')->nullable();
             $table->string('causer_id')->nullable();
+            $table->string('tenant_type')->nullable();
+            $table->string('tenant_id')->nullable();
             $table->jsonb('metadata')->nullable();
             $table->timestamp('created_at');
             $table->string('source')->nullable();
@@ -81,6 +96,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
             $table->timestamp('anonymized_at')->nullable();
             $table->index('entity_id');
             $table->index('causer_id');
+            $table->index('tenant_id');
             $table->index('created_at');
             $table->index('action');
             $table->index('source');
@@ -89,6 +105,7 @@ final class PostgreSQLDriver implements AuditDriverInterface
             $table->index('anonymized_at');
             $table->index(['entity_id', 'action']);
             $table->index(['entity_id', 'created_at']);
+            $table->index(['tenant_id', 'created_at']);
             $table->index(['causer_id', 'action']);
             $table->index(['action', 'created_at']);
         });
@@ -138,11 +155,48 @@ final class PostgreSQLDriver implements AuditDriverInterface
             'created_at' => $log->getCreatedAt(),
             'source' => $log->getSource(),
         ];
+
+        $payload = $this->withV2Context($log, $payload);
+
         $hash = app(AuditHash::class);
         if ($hash->enabled()) {
             $previousHash = $this->latestHashForEntity($log->getEntityType());
             $payload['previous_hash'] = $previousHash;
             $payload['audit_hash'] = $hash->compute($log, $previousHash);
+        }
+
+        return $this->filterPayloadForTable($this->getTableName($log->getEntityType()), $payload);
+    }
+
+    private function payloadForInsert(AuditLogInterface $log): array
+    {
+        return array_map(
+            fn (mixed $value): mixed => is_array($value) ? json_encode($value, JSON_THROW_ON_ERROR) : $value,
+            $this->payloadForLog($log)
+        );
+    }
+
+    private function withV2Context(AuditLogInterface $log, array $payload): array
+    {
+        if ((bool) config('audit-logger.tenant.enabled', false)) {
+            $tenant = app(TenantResolverInterface::class)->resolve();
+            $payload[config('audit-logger.tenant.columns.type', 'tenant_type')] = $tenant['type'];
+            $payload[config('audit-logger.tenant.columns.id', 'tenant_id')] = $tenant['id'];
+        }
+
+        if ((bool) config('audit-logger.changes.store', false)) {
+            $payload[(string) config('audit-logger.changes.column', 'changes')] = app(AuditChangeSet::class)->make($log->getOldValues(), $log->getNewValues());
+        }
+
+        return $payload;
+    }
+
+    private function filterPayloadForTable(string $tableName, array $payload): array
+    {
+        foreach (array_keys($payload) as $column) {
+            if (! Schema::connection($this->connection)->hasColumn($tableName, $column)) {
+                unset($payload[$column]);
+            }
         }
 
         return $payload;

--- a/src/Events/AuditCreated.php
+++ b/src/Events/AuditCreated.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Events;
+
+use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+
+final class AuditCreated
+{
+    public function __construct(public readonly AuditLogInterface $auditLog) {}
+}

--- a/src/Events/AuditCreating.php
+++ b/src/Events/AuditCreating.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Events;
+
+use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+
+final class AuditCreating
+{
+    public function __construct(public readonly AuditLogInterface $auditLog) {}
+}

--- a/src/Events/AuditVerificationFailed.php
+++ b/src/Events/AuditVerificationFailed.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Events;
+
+final class AuditVerificationFailed
+{
+    /** @param array<int, array<string, mixed>> $failures */
+    public function __construct(
+        public readonly string $entityClass,
+        public readonly array $failures
+    ) {}
+}

--- a/src/Http/Resources/AuditDiffResource.php
+++ b/src/Http/Resources/AuditDiffResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class AuditDiffResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'field' => $this->resource['field'] ?? null,
+            'old' => $this->resource['old'] ?? null,
+            'new' => $this->resource['new'] ?? null,
+            'type' => $this->resource['type'] ?? null,
+            'label' => $this->resource['label'] ?? null,
+        ];
+    }
+}

--- a/src/Http/Resources/AuditLogResource.php
+++ b/src/Http/Resources/AuditLogResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class AuditLogResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->resource->getKey(),
+            'entity_id' => $this->resource->entity_id,
+            'action' => $this->resource->action,
+            'old_values' => $this->resource->old_values,
+            'new_values' => $this->resource->new_values,
+            'changes' => $this->resource->changes,
+            'causer_type' => $this->resource->causer_type,
+            'causer_id' => $this->resource->causer_id,
+            'tenant_type' => $this->resource->tenant_type ?? null,
+            'tenant_id' => $this->resource->tenant_id ?? null,
+            'metadata' => $this->resource->metadata,
+            'source' => $this->resource->source,
+            'audit_hash' => $this->resource->audit_hash ?? null,
+            'previous_hash' => $this->resource->previous_hash ?? null,
+            'created_at' => $this->resource->created_at,
+        ];
+    }
+}

--- a/src/Http/Resources/AuditTimelineResource.php
+++ b/src/Http/Resources/AuditTimelineResource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Http\Resources;
+
+use Illuminate\Http\Resources\Json\JsonResource;
+
+final class AuditTimelineResource extends JsonResource
+{
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->resource['id'] ?? null,
+            'action' => $this->resource['action'] ?? null,
+            'entity_id' => $this->resource['entity_id'] ?? null,
+            'causer_type' => $this->resource['causer_type'] ?? null,
+            'causer_id' => $this->resource['causer_id'] ?? null,
+            'source' => $this->resource['source'] ?? null,
+            'created_at' => $this->resource['created_at'] ?? null,
+            'changes' => $this->resource['changes'] ?? [],
+            'metadata' => $this->resource['metadata'] ?? [],
+            'audit_hash' => $this->resource['audit_hash'] ?? null,
+            'previous_hash' => $this->resource['previous_hash'] ?? null,
+        ];
+    }
+}

--- a/src/Jobs/ProcessAuditLogJob.php
+++ b/src/Jobs/ProcessAuditLogJob.php
@@ -6,11 +6,13 @@ namespace iamfarhad\LaravelAuditLog\Jobs;
 
 use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
+use iamfarhad\LaravelAuditLog\Events\AuditCreated;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Event;
 
 final class ProcessAuditLogJob implements ShouldQueue
 {
@@ -23,24 +25,19 @@ final class ProcessAuditLogJob implements ShouldQueue
         public AuditLogInterface $log,
         protected AuditDriverInterface $driver
     ) {
-
-        // Configure queue settings
         $this->onQueue(config('audit-logger.queue.queue_name', 'audit'));
         $this->onConnection(config('audit-logger.queue.connection', null));
 
-        // Set delay if configured
         $delay = config('audit-logger.queue.delay', 0);
         if ($delay > 0) {
             $this->delay($delay);
         }
     }
 
-    /**
-     * Execute the job.
-     */
     public function handle(): void
     {
-        // Store the log
         $this->driver->store($this->log);
+
+        Event::dispatch(new AuditCreated($this->log));
     }
 }

--- a/src/Models/EloquentAuditLog.php
+++ b/src/Models/EloquentAuditLog.php
@@ -17,8 +17,11 @@ final class EloquentAuditLog extends Model
         'action',
         'old_values',
         'new_values',
+        'changes',
         'causer_type',
         'causer_id',
+        'tenant_type',
+        'tenant_id',
         'metadata',
         'created_at',
         'source',
@@ -29,8 +32,19 @@ final class EloquentAuditLog extends Model
     protected $casts = [
         'old_values' => 'json',
         'new_values' => 'json',
+        'changes' => 'array',
         'metadata' => 'array',
     ];
+
+    protected static function booted(): void
+    {
+        if (! (bool) config('audit-logger.security.append_only', false)) {
+            return;
+        }
+
+        static::updating(fn (): bool => false);
+        static::deleting(fn (): bool => false);
+    }
 
     public function getConnectionName(): ?string
     {
@@ -50,6 +64,11 @@ final class EloquentAuditLog extends Model
         return $this->morphTo();
     }
 
+    public function tenant()
+    {
+        return $this->morphTo(__FUNCTION__, 'tenant_type', 'tenant_id');
+    }
+
     public function scopeForEntity(Builder $query, $entityClass): Builder
     {
         return $query;
@@ -63,6 +82,17 @@ final class EloquentAuditLog extends Model
     public function scopeForAction(Builder $query, $action): Builder
     {
         return is_array($action) ? $query->whereIn('action', $action) : $query->where('action', $action);
+    }
+
+    public function scopeForTenant(Builder $query, string|int $tenantId, ?string $tenantType = null): Builder
+    {
+        $query->where('tenant_id', (string) $tenantId);
+
+        if ($tenantType !== null) {
+            $query->where('tenant_type', $tenantType);
+        }
+
+        return $query;
     }
 
     public function scopeForCauser(Builder $query, $causerClass): Builder
@@ -167,21 +197,12 @@ final class EloquentAuditLog extends Model
 
     public static function forEntity(string $entityClass): static
     {
+        $instance = new self;
+        $instance->setTable(app(\iamfarhad\LaravelAuditLog\Services\AuditTableNameResolver::class)->resolve($entityClass));
+
         $config = config('audit-logger');
         $driverName = $config['default'] ?? 'mysql';
         $driverConfig = $config['drivers'][$driverName] ?? $config['drivers']['mysql'] ?? [];
-        $entityConfig = $config['entities'][$entityClass] ?? [];
-        $tableName = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? null;
-
-        if ($tableName === null) {
-            $tablePrefix = $driverConfig['table_prefix'] ?? 'audit_';
-            $tableSuffix = $driverConfig['table_suffix'] ?? '_logs';
-            $tableName = $tablePrefix.Str::plural(Str::snake(class_basename($entityClass))).$tableSuffix;
-        }
-
-        $instance = new self;
-        $instance->setTable($tableName);
-
         $connection = $driverConfig['connection'] ?? config('database.default');
         if ($connection) {
             $instance->setConnection($connection);

--- a/src/Services/AuditAuthorization.php
+++ b/src/Services/AuditAuthorization.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
+
+final class AuditAuthorization
+{
+    public function canView(Model $model): bool
+    {
+        return $this->allows((string) config('audit-logger.authorization.view_gate', 'viewAuditLogs'), $model);
+    }
+
+    public function canRestore(Model $model): bool
+    {
+        return $this->allows((string) config('audit-logger.authorization.restore_gate', 'restoreFromAudit'), $model);
+    }
+
+    private function allows(string $gate, Model $model): bool
+    {
+        if (! (bool) config('audit-logger.authorization.enabled', false)) {
+            return true;
+        }
+
+        return Gate::allows($gate, $model);
+    }
+}

--- a/src/Services/AuditChangeSet.php
+++ b/src/Services/AuditChangeSet.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+final class AuditChangeSet
+{
+    /**
+     * @return array<int, array{field: string, old: mixed, new: mixed, type: string, label: string}>
+     */
+    public function make(?array $oldValues, ?array $newValues): array
+    {
+        $oldValues ??= [];
+        $newValues ??= [];
+        $fields = array_unique(array_merge(array_keys($oldValues), array_keys($newValues)));
+        $changes = [];
+
+        foreach ($fields as $field) {
+            $old = $oldValues[$field] ?? null;
+            $new = $newValues[$field] ?? null;
+
+            if ($old === $new) {
+                continue;
+            }
+
+            $changes[] = [
+                'field' => (string) $field,
+                'old' => $old,
+                'new' => $new,
+                'type' => $this->typeFor($new ?? $old),
+                'label' => str((string) $field)->replace('_', ' ')->title()->toString(),
+            ];
+        }
+
+        return $changes;
+    }
+
+    private function typeFor(mixed $value): string
+    {
+        return match (true) {
+            is_bool($value) => 'boolean',
+            is_int($value) => 'integer',
+            is_float($value) => 'float',
+            is_array($value) => 'array',
+            $value === null => 'null',
+            default => 'string',
+        };
+    }
+}

--- a/src/Services/AuditConfigValidator.php
+++ b/src/Services/AuditConfigValidator.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Contracts\FieldTransformerInterface;
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
+
+final class AuditConfigValidator
+{
+    /** @return array{errors: array<int, string>, warnings: array<int, string>} */
+    public function validate(): array
+    {
+        $errors = [];
+        $warnings = [];
+        $driver = (string) config('audit-logger.default', 'mysql');
+
+        if (! in_array($driver, ['mysql', 'postgresql', 'pgsql'], true)) {
+            $errors[] = "Unsupported audit driver [{$driver}].";
+        }
+
+        if ((bool) config('audit-logger.security.hashing.enabled', false) && blank(config('audit-logger.security.hashing.key'))) {
+            $errors[] = 'Audit hash-chain is enabled but no AUDIT_HASH_KEY or APP_KEY is configured.';
+        }
+
+        $tenantResolver = config('audit-logger.tenant.resolver');
+        if ((bool) config('audit-logger.tenant.enabled', false) && is_string($tenantResolver)) {
+            if (! class_exists($tenantResolver)) {
+                $errors[] = "Tenant resolver [{$tenantResolver}] does not exist.";
+            } elseif (! is_subclass_of($tenantResolver, TenantResolverInterface::class)) {
+                $errors[] = "Tenant resolver [{$tenantResolver}] must implement ".TenantResolverInterface::class.'.';
+            }
+        }
+
+        foreach ((array) config('audit-logger.fields.transformers', []) as $field => $transformer) {
+            if (! is_string($transformer) || ! class_exists($transformer)) {
+                $errors[] = "Transformer for field [{$field}] does not exist.";
+                continue;
+            }
+
+            if (! is_subclass_of($transformer, FieldTransformerInterface::class)) {
+                $errors[] = "Transformer [{$transformer}] must implement ".FieldTransformerInterface::class.'.';
+            }
+        }
+
+        if ((bool) config('audit-logger.security.append_only', false) && ! (bool) config('audit-logger.security.hashing.enabled', false)) {
+            $warnings[] = 'Append-only mode is enabled without hash-chain verification.';
+        }
+
+        if ((bool) config('audit-logger.auto_migration', true)) {
+            $warnings[] = 'Auto-migration is enabled. For production, prefer generated migrations.';
+        }
+
+        return ['errors' => $errors, 'warnings' => $warnings];
+    }
+}

--- a/src/Services/AuditHashVerifier.php
+++ b/src/Services/AuditHashVerifier.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace iamfarhad\LaravelAuditLog\Services;
 
 use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use iamfarhad\LaravelAuditLog\Events\AuditVerificationFailed;
 use iamfarhad\LaravelAuditLog\Models\EloquentAuditLog;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Schema;
 use Throwable;
 
@@ -21,14 +23,14 @@ final class AuditHashVerifier
         $table = $model->getTable();
 
         if (! Schema::connection($connection)->hasTable($table)) {
-            return $this->failure('missing_audit_table', "Audit table [{$table}] does not exist.");
+            return $this->failed($entityClass, $this->failure('missing_audit_table', "Audit table [{$table}] does not exist."));
         }
 
         if (! Schema::connection($connection)->hasColumn($table, 'audit_hash') || ! Schema::connection($connection)->hasColumn($table, 'previous_hash')) {
-            return $this->failure(
+            return $this->failed($entityClass, $this->failure(
                 'missing_hash_columns',
                 "Audit table [{$table}] must have nullable [audit_hash] and [previous_hash] columns before hash-chain verification can run."
-            );
+            ));
         }
 
         $previousHash = null;
@@ -72,10 +74,12 @@ final class AuditHashVerifier
                 $previousHash = $log->audit_hash ?? null;
             }
         } catch (Throwable $exception) {
-            return $this->failure('verification_query_failed', $exception->getMessage());
+            return $this->failed($entityClass, $this->failure('verification_query_failed', $exception->getMessage()));
         }
 
-        return ['valid' => $failures === [], 'checked' => $checked, 'failures' => $failures];
+        $result = ['valid' => $failures === [], 'checked' => $checked, 'failures' => $failures];
+
+        return $failures === [] ? $result : $this->failed($entityClass, $result);
     }
 
     /** @return array{valid: false, checked: 0, failures: array<int, array<string, string>>} */
@@ -88,5 +92,13 @@ final class AuditHashVerifier
                 ['code' => $code, 'message' => $message],
             ],
         ];
+    }
+
+    /** @param array{valid: bool, checked: int, failures: array<int, array<string, mixed>>} $result */
+    private function failed(string $entityClass, array $result): array
+    {
+        Event::dispatch(new AuditVerificationFailed($entityClass, $result['failures']));
+
+        return $result;
     }
 }

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -44,7 +44,11 @@ final class AuditLogger
             return;
         }
 
-        if ((bool) config('audit-logger.batch.enabled', false) && ! (bool) config('audit-logger.queue.enabled', false)) {
+        $canUseNativeBatch = (bool) config('audit-logger.batch.enabled', false)
+            && ! (bool) config('audit-logger.queue.enabled', false)
+            && ! app(AuditHash::class)->enabled();
+
+        if ($canUseNativeBatch) {
             foreach ($logs as $log) {
                 Event::dispatch(new AuditCreating($log));
             }

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -8,9 +8,12 @@ use iamfarhad\LaravelAuditLog\Contracts\AuditDriverInterface;
 use iamfarhad\LaravelAuditLog\Contracts\AuditLogInterface;
 use iamfarhad\LaravelAuditLog\Drivers\MySQLDriver;
 use iamfarhad\LaravelAuditLog\Drivers\PostgreSQLDriver;
+use iamfarhad\LaravelAuditLog\Events\AuditCreated;
+use iamfarhad\LaravelAuditLog\Events\AuditCreating;
 use iamfarhad\LaravelAuditLog\Jobs\ProcessAuditLogJob;
 use iamfarhad\LaravelAuditLog\Jobs\ProcessAuditLogSyncJob;
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Request;
 
 final class AuditLogger
@@ -23,11 +26,15 @@ final class AuditLogger
             return;
         }
 
+        Event::dispatch(new AuditCreating($log));
+
         if ((bool) config('audit-logger.queue.enabled', false)) {
             ProcessAuditLogJob::dispatch($log, $this->driver);
         } else {
             ProcessAuditLogSyncJob::dispatchSync($log, $this->driver);
         }
+
+        Event::dispatch(new AuditCreated($log));
     }
 
     /** @param array<AuditLogInterface> $logs */
@@ -38,7 +45,15 @@ final class AuditLogger
         }
 
         if ((bool) config('audit-logger.batch.enabled', false) && ! (bool) config('audit-logger.queue.enabled', false)) {
+            foreach ($logs as $log) {
+                Event::dispatch(new AuditCreating($log));
+            }
+
             $this->driver->storeBatch($logs);
+
+            foreach ($logs as $log) {
+                Event::dispatch(new AuditCreated($log));
+            }
 
             return;
         }

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -33,16 +33,18 @@ final class AuditLogger
     /** @param array<AuditLogInterface> $logs */
     public function batch(array $logs): void
     {
-        if (! (bool) config('audit-logger.enabled', true)) {
+        if (! (bool) config('audit-logger.enabled', true) || $logs === []) {
+            return;
+        }
+
+        if ((bool) config('audit-logger.batch.enabled', false) && ! (bool) config('audit-logger.queue.enabled', false)) {
+            $this->driver->storeBatch($logs);
+
             return;
         }
 
         foreach ($logs as $log) {
-            if ((bool) config('audit-logger.queue.enabled', false)) {
-                ProcessAuditLogJob::dispatch($log, $this->driver);
-            } else {
-                ProcessAuditLogSyncJob::dispatchSync($log, $this->driver);
-            }
+            $this->log($log);
         }
     }
 

--- a/src/Services/AuditLogger.php
+++ b/src/Services/AuditLogger.php
@@ -30,10 +30,11 @@ final class AuditLogger
 
         if ((bool) config('audit-logger.queue.enabled', false)) {
             ProcessAuditLogJob::dispatch($log, $this->driver);
-        } else {
-            ProcessAuditLogSyncJob::dispatchSync($log, $this->driver);
+
+            return;
         }
 
+        ProcessAuditLogSyncJob::dispatchSync($log, $this->driver);
         Event::dispatch(new AuditCreated($log));
     }
 

--- a/src/Services/AuditMigrationGenerator.php
+++ b/src/Services/AuditMigrationGenerator.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Str;
+
+final class AuditMigrationGenerator
+{
+    public function __construct(private readonly Filesystem $files) {}
+
+    public function create(string $entityClass): string
+    {
+        $tableName = app(AuditTableNameResolver::class)->resolve($entityClass);
+        $className = 'Create'.Str::studly($tableName).'Table';
+        $timestamp = now()->format('Y_m_d_His');
+        $path = database_path("migrations/{$timestamp}_create_{$tableName}_table.php");
+
+        $this->files->ensureDirectoryExists(dirname($path));
+        $this->files->put($path, $this->stub($className, $tableName));
+
+        return $path;
+    }
+
+    private function stub(string $className, string $tableName): string
+    {
+        return <<<PHP
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('{$tableName}', function (Blueprint \$table): void {
+            \$table->id();
+            \$table->string('entity_id');
+            \$table->string('action');
+            \$table->json('old_values')->nullable();
+            \$table->json('new_values')->nullable();
+            \$table->json('changes')->nullable();
+            \$table->string('causer_type')->nullable();
+            \$table->string('causer_id')->nullable();
+            \$table->string('tenant_type')->nullable();
+            \$table->string('tenant_id')->nullable();
+            \$table->json('metadata')->nullable();
+            \$table->timestamp('created_at');
+            \$table->string('source')->nullable();
+            \$table->string('audit_hash', 128)->nullable();
+            \$table->string('previous_hash', 128)->nullable();
+            \$table->timestamp('anonymized_at')->nullable();
+            \$table->index('entity_id');
+            \$table->index('causer_id');
+            \$table->index('tenant_id');
+            \$table->index('created_at');
+            \$table->index('action');
+            \$table->index('source');
+            \$table->index(['entity_id', 'action']);
+            \$table->index(['entity_id', 'created_at']);
+            \$table->index(['tenant_id', 'created_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('{$tableName}');
+    }
+};
+PHP;
+    }
+}

--- a/src/Services/AuditRestorer.php
+++ b/src/Services/AuditRestorer.php
@@ -39,8 +39,13 @@ final class AuditRestorer
 
     private function apply(Model $model, EloquentAuditLog|int|string $auditLog, string $mode, bool $save): Model
     {
+        if (! app(AuditAuthorization::class)->canRestore($model)) {
+            throw new InvalidArgumentException('You are not authorized to restore this model from audit history.');
+        }
+
         $log = $this->resolveLog($model, $auditLog);
         $values = $this->valuesForMode($log, $mode);
+        $values = $this->filterRestorableValues($model, $values);
 
         if ($values === []) {
             throw new InvalidArgumentException("The selected audit log does not contain {$mode} values to apply.");
@@ -49,7 +54,7 @@ final class AuditRestorer
         $model->forceFill($values);
 
         if ($save) {
-            $model->save();
+            $this->saveModel($model);
         }
 
         return $model;
@@ -96,5 +101,38 @@ final class AuditRestorer
         };
 
         return is_array($values) ? $values : [];
+    }
+
+    /** @param array<string, mixed> $values */
+    private function filterRestorableValues(Model $model, array $values): array
+    {
+        if (! (bool) config('audit-logger.restore.validate_fillable', false)) {
+            return $values;
+        }
+
+        return array_intersect_key($values, array_flip($model->getFillable()));
+    }
+
+    private function saveModel(Model $model): void
+    {
+        if ((bool) config('audit-logger.restore.audit_restores', true)) {
+            $model->save();
+
+            return;
+        }
+
+        $wasAuditingEnabled = method_exists($model, 'isAuditingEnabled') ? $model->isAuditingEnabled() : null;
+
+        if (method_exists($model, 'disableAuditing')) {
+            $model->disableAuditing();
+        }
+
+        try {
+            $model->save();
+        } finally {
+            if ($wasAuditingEnabled === true && method_exists($model, 'enableAuditing')) {
+                $model->enableAuditing();
+            }
+        }
     }
 }

--- a/src/Services/AuditSnapshotService.php
+++ b/src/Services/AuditSnapshotService.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use Carbon\Carbon;
+use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
+use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+
+final class AuditSnapshotService
+{
+    public function maybeSnapshot(Model $model): void
+    {
+        if (! (bool) config('audit-logger.snapshots.enabled', false) || ! method_exists($model, 'getAuditEntityType')) {
+            return;
+        }
+
+        $every = max(1, (int) config('audit-logger.snapshots.every', 20));
+        $count = \iamfarhad\LaravelAuditLog\Models\EloquentAuditLog::forEntity($model::class)
+            ->newQuery()
+            ->where('entity_id', (string) $model->getKey())
+            ->count();
+
+        if ($count === 0 || $count % $every !== 0) {
+            return;
+        }
+
+        $this->snapshot($model);
+    }
+
+    public function snapshot(Model $model): void
+    {
+        if (! method_exists($model, 'getAuditEntityType')) {
+            return;
+        }
+
+        $auditLogger = app(AuditLogger::class);
+        $causer = app(CauserResolverInterface::class)->resolve();
+
+        $auditLogger->log(new AuditLog(
+            entityType: $model->getAuditEntityType(),
+            entityId: $model->getKey(),
+            action: 'snapshot',
+            oldValues: null,
+            newValues: $model->getAttributes(),
+            metadata: ['snapshot' => true],
+            causerType: $causer['type'],
+            causerId: $causer['id'],
+            createdAt: Carbon::now(),
+            source: $auditLogger->getSource(),
+        ));
+    }
+}

--- a/src/Services/AuditTableNameResolver.php
+++ b/src/Services/AuditTableNameResolver.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use Illuminate\Support\Str;
+
+final class AuditTableNameResolver
+{
+    public function resolve(string $entityClass): string
+    {
+        $config = config('audit-logger');
+        $driver = $config['default'] ?? 'mysql';
+        $driverConfig = $config['drivers'][$driver] ?? $config['drivers']['mysql'] ?? [];
+        $entityConfig = $config['entities'][$entityClass] ?? [];
+        $configuredTable = $entityConfig['audit_table'] ?? $entityConfig['table'] ?? null;
+
+        if (is_string($configuredTable) && $configuredTable !== '') {
+            return $configuredTable;
+        }
+
+        return ($driverConfig['table_prefix'] ?? 'audit_')
+            .Str::plural(Str::snake(class_basename($entityClass)))
+            .($driverConfig['table_suffix'] ?? '_logs');
+    }
+}

--- a/src/Services/RelationshipAuditor.php
+++ b/src/Services/RelationshipAuditor.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use Carbon\Carbon;
+use iamfarhad\LaravelAuditLog\Contracts\CauserResolverInterface;
+use iamfarhad\LaravelAuditLog\DTOs\AuditLog;
+use Illuminate\Database\Eloquent\Model;
+
+final class RelationshipAuditor
+{
+    public function log(Model $model, string $relation, string $action, mixed $relatedIds, array $metadata = []): void
+    {
+        if (! method_exists($model, 'getAuditEntityType')) {
+            return;
+        }
+
+        $auditLogger = app(AuditLogger::class);
+        $causer = app(CauserResolverInterface::class)->resolve();
+
+        $auditLogger->log(new AuditLog(
+            entityType: $model->getAuditEntityType(),
+            entityId: $model->getKey(),
+            action: $action,
+            oldValues: null,
+            newValues: [
+                'relation' => $relation,
+                'related_ids' => is_array($relatedIds) ? $relatedIds : [$relatedIds],
+            ],
+            metadata: array_merge($metadata, ['relation' => $relation]),
+            causerType: $causer['type'],
+            causerId: $causer['id'],
+            createdAt: Carbon::now(),
+            source: $auditLogger->getSource(),
+        ));
+    }
+
+    public function attached(Model $model, string $relation, mixed $relatedIds, array $metadata = []): void
+    {
+        $this->log($model, $relation, $relation.'_attached', $relatedIds, $metadata);
+    }
+
+    public function detached(Model $model, string $relation, mixed $relatedIds, array $metadata = []): void
+    {
+        $this->log($model, $relation, $relation.'_detached', $relatedIds, $metadata);
+    }
+
+    public function synced(Model $model, string $relation, mixed $relatedIds, array $metadata = []): void
+    {
+        $this->log($model, $relation, $relation.'_synced', $relatedIds, $metadata);
+    }
+}

--- a/src/Services/TenantResolver.php
+++ b/src/Services/TenantResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace iamfarhad\LaravelAuditLog\Services;
+
+use iamfarhad\LaravelAuditLog\Contracts\TenantResolverInterface;
+
+final class TenantResolver implements TenantResolverInterface
+{
+    /** @return array{type: class-string|string|null, id: string|int|null} */
+    public function resolve(): array
+    {
+        $resolver = config('audit-logger.tenant.resolver');
+
+        if (is_string($resolver) && $resolver !== static::class && app()->bound($resolver)) {
+            return app($resolver)->resolve();
+        }
+
+        $tenant = null;
+
+        if (function_exists('tenant')) {
+            $tenant = tenant();
+        }
+
+        if ($tenant === null && app()->bound('currentTenant')) {
+            $tenant = app('currentTenant');
+        }
+
+        if (is_object($tenant) && method_exists($tenant, 'getKey')) {
+            return ['type' => $tenant::class, 'id' => $tenant->getKey()];
+        }
+
+        return ['type' => null, 'id' => null];
+    }
+}


### PR DESCRIPTION
## Summary

This PR builds the v2 major-release infrastructure on top of `feature/audit-advanced-apis` / PR #8.

Included:

- Production migration tooling:
  - `audit:make-migration`
  - `audit:migrate`
  - `AuditMigrationGenerator`
- True driver-level batch insert support when `AUDIT_BATCH_ENABLED=true`, queueing is disabled, and hash-chain mode is off
- Multi-tenancy support:
  - `TenantResolverInterface`
  - default `TenantResolver`
  - optional `tenant_type` / `tenant_id` payload columns
  - `forTenant()` audit scope
- Append-only Eloquent protection for audit rows via `AUDIT_APPEND_ONLY=true`
- Relationship auditing helper:
  - `RelationshipAuditor::attached()`
  - `RelationshipAuditor::detached()`
  - `RelationshipAuditor::synced()`
- Operational commands:
  - `audit:config-check`
  - `audit:doctor`
  - `audit:stats`
  - `audit:timeline`
  - `audit:diff`
  - `audit:verify`
  - `audit:partition`
  - `audit:upgrade`
- Config validation service
- Authorization helper service
- Computed change-set support via optional `changes` column
- Snapshot service
- API resources:
  - `AuditLogResource`
  - `AuditTimelineResource`
  - `AuditDiffResource`
- Audit lifecycle events:
  - `AuditCreating`
  - `AuditCreated`
  - `AuditVerificationFailed`
- Rich top-level README coverage for all v2 features
- Expanded v2 documentation in `docs/v2-major-release.md`

Excluded by request:

- Filament plugin
- Nova / Backpack integrations
- New external storage drivers such as ClickHouse, OpenSearch, S3, and webhook drivers

## Documentation updates

- Reworked `README.md` into a full feature guide covering v2 installation, config, production table management, search/analytics/timeline/diff, restore safety, integrity/security, redaction, tenancy, batch inserts, relationship auditing, snapshots, API resources, commands, retention, events, upgrades, comparison, troubleshooting, and docs links.
- Expanded `docs/v2-major-release.md` into a deeper production guide with migration examples, PostgreSQL/MySQL upgrade examples, batch limitations, tenancy resolver examples, hash-chain behavior, relationship auditing, restore safety, API resources, operational commands, partition guidance, events, presets, production checklist, troubleshooting, and upgrade order.

## Hardening / review fixes

- `audit:migrate` now explicitly creates storage instead of relying on `ensureStorageExists()`, so it works even when runtime auto-migration is disabled.
- Native batch inserts are disabled automatically when hash-chain mode is enabled, preserving sequential hash-chain integrity.
- Queued audit writes now dispatch `AuditCreated` from the queued job after storage succeeds instead of dispatching too early.
- `audit:doctor` and `audit:upgrade` use the configured audit connection rather than the app default database connection.
- Restore/rollback now uses `AuditAuthorization`, supports fillable filtering, and can save without creating a new audit row when `AUDIT_RESTORE_AUDIT=false`.
- Hash-chain verification dispatches `AuditVerificationFailed` when verification fails.

## Notes

This is intentionally a stacked PR on top of PR #8 so the advanced audit APIs can stay reviewable and mergeable independently.

The v2 features are mostly opt-in through config flags. Existing tables are protected by payload filtering, so optional v2 columns are only written when present.

The partition command is guidance-only and does not run risky database partition DDL automatically.

Relationship auditing is explicit via `RelationshipAuditor`; it does not monkey-patch Laravel relation methods.

## Verification

This PR is still draft because GitHub Actions do not run for this stacked PR target: the repository workflows are configured for pull requests into `main` / `master`, while this PR targets `feature/audit-advanced-apis`.

Recommended after PR #8 is merged or this PR is retargeted to `main`:

```bash
composer install
composer test
composer pint:test
```

Then mark ready only after the full matrix is green.